### PR TITLE
Disable 64bit feature in mke2fs for syslinux>=6.03

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -1267,7 +1267,7 @@ fi
 
 echo "Updating boot config file"
 # adjust label and fstype
-sed -i -e "s/CDLABEL=[^ ]*/$TGTLABEL/" -e "s/rootfstype=[^ ]*/rootfstype=$TGTFS/" -e "s/LABEL=[^ :]*/$TGTLABEL/" $BOOTCONFIG  $BOOTCONFIG_EFI
+sed -i -e "s/CDLABEL=[^ ]*/$TGTLABEL/g" -e "s/rootfstype=[^ ]*/rootfstype=$TGTFS/" -e "s/LABEL=[^ :]*/$TGTLABEL/g" $BOOTCONFIG  $BOOTCONFIG_EFI
 if [ -n "$kernelargs" ]; then
     sed -i -e "s;initrd.\?\.img;& ${kernelargs};" $BOOTCONFIG
     if [ -n "$efi" ]; then

--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -559,7 +559,7 @@ createEXTFSLayout() {
     else
         mkfs=/sbin/mkfs.ext4
     fi
-    $mkfs -L $label $TGTDEV
+    $mkfs -O ^64bit -L $label $TGTDEV
     TGTLABEL="UUID=$(/sbin/blkid -s UUID -o value $TGTDEV)"
 }
 


### PR DESCRIPTION
livecd-iso-to-disk does not work on Fedora25 using mke2fs >= 1.43 and syslinux >= 6.03, see:

http://www.syslinux.org/wiki/index.php?title=Filesystem