### PR TITLE
livecd-iso-to-disk: Cleanup sed statements

### DIFF
--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -6,7 +6,7 @@ livecd-iso-to-disk - Installs bootable Live images onto USB/SD storage devices.
 
 =head1 SYNOPSIS
 
-B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <time>] [--totaltimeout <time>] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--swap-size-mb <size>] [--overlay-size-mb <size>] [--home-size-mb <size>] [--delete-home] [--crypted-home] [--unencrypted-home] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
+B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--swap-size-mb <size>] [--overlay-size-mb <size>] [--home-size-mb <size>] [--delete-home] [--crypted-home] [--unencrypted-home] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
 
 Simplest
 
@@ -86,13 +86,23 @@ Used to prepare an image for the OLPC XO-1 laptop with its compressed, JFFS2 fil
 
 Used together with the --xo option to prepare an image for an OLPC XO laptop with the home directory on an SD card instead of the internal flash storage.
 
-=item --timeout <time>
+=item --timeout <duration>
 
-Modifies the bootloader's timeout value, which indicates how long to pause at the boot: prompt before booting automatically.  This overrides the value set during iso creation.  Units are 1/10 s.  The timeout is canceled when any key is pressed, the assumption being that the user will complete the command line.  A timeout of zero will disable the timeout completely.
+Modifies the bootloader's timeout value, which indicates how long to pause at the boot prompt before booting automatically.  This overrides the value set during iso creation.
 
-=item --totaltimeout <time>
+=over 4
 
-Adds a bootloader totaltimeout, which indicates how long to wait before booting automatically.  This is used to force an automatic boot.  This timeout cannot be canceled by the user.  Units are 1/10 s.
+For SYSLINUX, a timeout unit is 1/10 second; the timeout is canceled when any key is pressed (the assumption being that the user will complete the command line); and a timeout of zero will disable the timeout completely.
+
+For EFI GRUB, the timeout unit is 1 second; timeout specifies the time to wait for keyboard input before booting the default menu entry.  A timeout of ‘0’ means to boot the default entry immediately without displaying the menu; and a timeout of ‘-1’ means to wait indefinitely.
+
+=back
+
+Enter a desired timeout value in 1/10 second units (or ‘-1’) and the appropriate value will be supplied to the configuration file.  For immediate booting, enter ‘-0’ to avoid the ambiguity between systems.  An entry of ‘-0’ will result in an SYSLINUX setting of timeout 1 and totaltimeout 1. ‘0’ or ‘-1’ will result in an SYSLINUX setting of ‘0’ (disable timeout, that is, wait indefinitely), but ‘0’ for EFI GRUB will mean immediate boot of the default, while ‘-1’ will mean EFI GRUB waits indefinitely for a user selection.
+
+=item --totaltimeout <duration>
+
+Adds a SYSLINUX bootloader totaltimeout, which indicates how long to wait before booting automatically.  This is used to force an automatic boot.  This timeout cannot be canceled by the user.  Units are 1/10 s.  A totaltimeout of zero will disable the timeout completely.  (This setting is not available in EFI GRUB.)
 
 =item --extra-kernel-args <args>
 

--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -471,7 +471,7 @@ createGPTLayout() {
     wipefs -a ${device}
     run_parted -s $device mklabel gpt
     partinfo=$(run_parted -s -m $device "unit MB print" |grep ^$device:)
-    dev_size=$(echo $partinfo |cut -d : -f 2 |sed -e 's/MB$//')
+    dev_size=$(echo $partinfo | cut -d : -f 2 | sed 's/MB$//')
     p1_size=$(($dev_size - 3))
 
     if [ $p1_size -le 0 ]; then
@@ -503,7 +503,7 @@ createMSDOSLayout() {
     wipefs -a ${device}
     run_parted -s $device mklabel msdos
     partinfo=$(run_parted -s -m $device "unit MB print" |grep ^$device:)
-    dev_size=$(echo $partinfo |cut -d : -f 2 |sed -e 's/MB$//')
+    dev_size=$(echo $partinfo | cut -d : -f 2 | sed 's/MB$//')
     p1_size=$(($dev_size - 3))
 
     if [ $p1_size -le 0 ]; then
@@ -535,7 +535,7 @@ createEXTFSLayout() {
     wipefs -a ${device}
     run_parted -s $device mklabel msdos
     partinfo=$(run_parted -s -m $device "u MB print" |grep ^$device:)
-    dev_size=$(echo $partinfo |cut -d : -f 2 |sed -e 's/MB$//')
+    dev_size=$(echo $partinfo | cut -d : -f 2 | sed 's/MB$//')
     p1_size=$(($dev_size - 3))
 
     if [ $p1_size -le 0 ]; then
@@ -1245,11 +1245,11 @@ if [ "$srctype" = "live" ]; then
     # file to a base state before updating.
     if [[ -d $SRCMNT/syslinux/ ]]; then
         echo "Preparing boot config file."
-        sed -i -e "s/root=live:[^ ]*/root=live:CDLABEL=name/"\
-               -e "s/\(r*d*.*live.*ima*ge*\) .* quiet/\1 quiet/"\
-                    $BOOTCONFIG $BOOTCONFIG_EFI
-        sed -i -e "s/^timeout.*$/timeout\ 100/"\
-               -e "/^totaltimeout.*$/d" $BOOTCONFIG
+        sed -i "s/root=live:[^ ]*/root=live:CDLABEL=name/
+                s/\(r*d*.*live.*ima*ge*\) .* quiet/\1 quiet/
+               " $BOOTCONFIG $BOOTCONFIG_EFI
+        sed -i "s/^timeout.*$/timeout\ 100/
+                /^totaltimeout.*$/d" $BOOTCONFIG
     fi
 fi
 
@@ -1267,23 +1267,25 @@ fi
 
 echo "Updating boot config file"
 # adjust label and fstype
-sed -i -e "s/CDLABEL=[^ ]*/$TGTLABEL/" -e "s/rootfstype=[^ ]*/rootfstype=$TGTFS/" -e "s/LABEL=[^ :]*/$TGTLABEL/" $BOOTCONFIG  $BOOTCONFIG_EFI
+sed -i "s/CDLABEL=[^ ]*/$TGTLABEL/
+        s/rootfstype=[^ ]*/rootfstype=$TGTFS/
+        s/LABEL=[^ :]*/$TGTLABEL/" $BOOTCONFIG $BOOTCONFIG_EFI
 if [ -n "$kernelargs" ]; then
-    sed -i -e "s;initrd.\?\.img;& ${kernelargs};" $BOOTCONFIG
+    sed -i "s;initrd.\?\.img;& ${kernelargs};" $BOOTCONFIG
     if [ -n "$efi" ]; then
-        sed -i -e "s;vmlinuz.\?;& ${kernelargs} ;" $BOOTCONFIG_EFI
+        sed -i "s;vmlinuz.\?;& ${kernelargs};" $BOOTCONFIG_EFI
     fi
 fi
 if [ "$LIVEOS" != "LiveOS" ]; then
-    sed -i -e "s;r*d*.*live.*ima*ge*;& live_dir=$LIVEOS;"\
-              $BOOTCONFIG $BOOTCONFIG_EFI
+    sed -i "s;r*d*.*live.*ima*ge*;& live_dir=$LIVEOS;
+           " $BOOTCONFIG $BOOTCONFIG_EFI
 fi
 
 # EFI images are in $SYSLINUXPATH now
 if [ -n "$efi" ]; then
-    sed -i -e "s;/isolinux/;/$SYSLINUXPATH/;g" $BOOTCONFIG_EFI
-    sed -i -e "s;/images/pxeboot/;/$SYSLINUXPATH/;g" $BOOTCONFIG_EFI
-    sed -i -e "s;findiso;;g" $BOOTCONFIG_EFI
+    sed -i "s;/isolinux/;/$SYSLINUXPATH/;g
+            s;/images/pxeboot/;/$SYSLINUXPATH/;g
+            s;findiso;;g" $BOOTCONFIG_EFI
 fi
 
 # DVD Installer for netinst
@@ -1292,16 +1294,16 @@ if [ "$srctype" != "live" ]; then
     # and non-install will have everything in the initrd
     if [ "$imgtype" != "install" ]; then
         # The initrd has everything, so no stage2
-        sed -i -e "s;\S*stage2=\S*;;g" $BOOTCONFIG $BOOTCONFIG_EFI
+        sed -i "s;\S*stage2=\S*;;g" $BOOTCONFIG $BOOTCONFIG_EFI
     fi
 fi
 
 # Adjust the boot timeouts
 if [ -n "$timeout" ]; then
-    sed -i -e "s/^timeout.*$/timeout\ $timeout/" $BOOTCONFIG
+    sed -i "s/^timeout.*$/timeout\ $timeout/" $BOOTCONFIG
 fi
 if [ -n "$totaltimeout" ]; then
-    sed -i -e "/^timeout.*$/a\totaltimeout\ $totaltimeout" $BOOTCONFIG
+    sed -i "/^timeout.*$/a\totaltimeout\ $totaltimeout" $BOOTCONFIG
 fi
 
 if [ "$overlaysizemb" -gt 0 ]; then
@@ -1315,9 +1317,8 @@ if [ "$overlaysizemb" -gt 0 ]; then
             dd if=/dev/null of=$TGTMNT/$LIVEOS/$OVERFILE count=1 bs=1M seek=$overlaysizemb
         fi
     fi
-    sed -i -e "s/r*d*.*live.*ima*ge*/& rd.live.overlay=${TGTLABEL} rw/"\
-              $BOOTCONFIG $BOOTCONFIG_EFI
-    sed -i -e "s/\ ro\ / /" $BOOTCONFIG  $BOOTCONFIG_EFI
+    sed -i "s/r*d*.*live.*ima*ge*/& rd.live.overlay=${TGTLABEL} rw/
+            s/\ ro\ / /" $BOOTCONFIG $BOOTCONFIG_EFI
 fi
 
 if [ "$swapsizemb" -gt 0 -a -z "$skipcopy" ]; then
@@ -1363,12 +1364,13 @@ fi
 # boot on the XO anyway.
 if [ -n "$xo" ]; then
     echo "Setting up /boot/olpc.fth file"
-    args=$(grep "^ *append" $TGTMNT/$SYSLINUXPATH/isolinux.cfg |head -n1 |sed -e 's/.*initrd=[^ ]*//')
+    args=$(grep "^ *append" $TGTMNT/$SYSLINUXPATH/isolinux.cfg | head -n1 |
+           sed 's/.*initrd=[^ ]*//')
     if [ -z "$xonohome" -a ! -f $TGTMNT/$LIVEOS/$HOMEFILE ]; then
         args="$args persistenthome=mtd0"
     fi
     args="$args reset_overlay"
-    xosyspath=$(echo $SYSLINUXPATH | sed -e 's;/;\\;')
+    xosyspath=$(echo $SYSLINUXPATH | sed 's;/;\\;')
     if [ ! -d $TGTMNT/boot ]; then
         mkdir -p $TGTMNT/boot
     fi
@@ -1472,8 +1474,9 @@ if [ -z "$multi" ]; then
     fi
 else
     # we need to do some more config file tweaks for multi-image mode
-    sed -i -e "s;kernel vm;kernel /$LIVEOS/syslinux/vm;" $TGTMNT/$SYSLINUXPATH/isolinux.cfg
-    sed -i -e "s;initrd=i;initrd=/$LIVEOS/syslinux/i;" $TGTMNT/$SYSLINUXPATH/isolinux.cfg
+    sed -i "s;kernel vm;kernel /$LIVEOS/syslinux/vm;
+            s;initrd=i;initrd=/$LIVEOS/syslinux/i;
+           " $TGTMNT/$SYSLINUXPATH/isolinux.cfg
     mv $TGTMNT/$SYSLINUXPATH/isolinux.cfg $TGTMNT/$SYSLINUXPATH/syslinux.cfg
     cleanup
 fi


### PR DESCRIPTION
Remove unnecessary elements, consolidate related calls,
update the resetting of BOOTCONFIG files to current defaults,
and add a missing call for a 'rw' flag for all live installations,
which fixes https://bugzilla.redhat.com/show_bug.cgi?id=1418315

This commit also changes labels globally as requested in the second commit of PR #43.