### PR TITLE
Remove absolute directories on external program call paths.

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -360,7 +360,7 @@ class ImageCreator(object):
         This method may be used by subclasses when executing programs inside
         the install root e.g.
 
-          subprocess.call(["/bin/ls"], preexec_fn = self.chroot)
+          subprocess.call(["ls"], preexec_fn = self.chroot)
 
         """
         os.chroot(self._instroot)
@@ -485,18 +485,20 @@ class ImageCreator(object):
         if not os.path.exists(self.__selinux_mountpoint):
             return
 
-        arglist = ["/bin/mount", "--bind", "/dev/null", self._instroot + self.__selinux_mountpoint + "/load"]
+        arglist = ["mount", "--bind", "/dev/null",
+                   self._instroot + self.__selinux_mountpoint + "/load"]
         subprocess.call(arglist, close_fds = True)
 
         if kickstart.selinux_enabled(self.ks):
             # label the fs like it is a root before the bind mounting
-            arglist = ["/sbin/setfiles", "-F", "-r", self._instroot, selinux.selinux_file_context_path(), self._instroot]
+            arglist = ["setfiles", "-F", "-r", self._instroot,
+                       selinux.selinux_file_context_path(), self._instroot]
             subprocess.call(arglist, close_fds = True)
             # these dumb things don't get magically fixed, so make the user generic
         # if selinux exists on the host we need to lie to the chroot
         if selinux.is_selinux_enabled():
             for f in ("/proc", "/sys"):
-                arglist = ["/usr/bin/chcon", "-u", "system_u", self._instroot + f]
+                arglist = ["chcon", "-u", "system_u", self._instroot + f]
                 subprocess.call(arglist, close_fds = True)
 
     def __destroy_selinuxfs(self):
@@ -506,7 +508,7 @@ class ImageCreator(object):
         # if the system was running selinux clean up our lies
         path = self._instroot + self.__selinux_mountpoint + "/load"
         if os.path.exists(path):
-            arglist = ["/bin/umount", path]
+            arglist = ["umount", path]
             subprocess.call(arglist, close_fds = True)
 
     def mount(self, base_on = None, cachedir = None):
@@ -806,7 +808,7 @@ class ImageCreator(object):
         this can be useful for debugging.
 
         """
-        subprocess.call(["/bin/bash"], preexec_fn = self._chroot)
+        subprocess.call(["bash"], preexec_fn = self._chroot)
 
     def package(self, destdir = "."):
         """Prepares the created image for final delivery.

--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -121,9 +121,7 @@ class LiveImageCreatorBase(LoopImageCreator):
 
         """
         r = kickstart.get_kernel_args(self.ks)
-        if os.path.exists(self._instroot + "/usr/bin/rhgb"):
-            r += " rhgb"
-        if os.path.exists(self._instroot + "/usr/bin/plymouth"):
+        if chroottypecheck('rhgb') or chroottypecheck('plymouth'):
             r += " rhgb"
         return r
 
@@ -147,7 +145,7 @@ class LiveImageCreatorBase(LoopImageCreator):
             return os.path.exists(instroot + path)
 
         if (exists(self._instroot, "/usr/lib/anaconda-runtime/checkisomd5") or
-            exists(self._instroot, "/usr/bin/checkisomd5")):
+            chroottypecheck('checkisomd5')):
             return True
 
         return False
@@ -317,7 +315,7 @@ class LiveImageCreatorBase(LoopImageCreator):
     def __create_iso(self, isodir):
         iso = self._outdir + "/" + self.name + ".iso"
 
-        args = ["/usr/bin/genisoimage",
+        args = ["genisoimage",
                 "-J", "-r",
                 "-hide-rr-moved", "-hide-joliet-trans-tbl",
                 "-V", self.fslabel,
@@ -332,25 +330,24 @@ class LiveImageCreatorBase(LoopImageCreator):
         if subprocess.call(args) != 0:
             raise CreatorError("ISO creation failed!")
 
-        if os.path.exists("/usr/bin/isohybrid"):
+        if subprocess.call(['type', 'isohybrid']):
             if os.path.exists(isodir + "/isolinux/efiboot.img"):
-                subprocess.call(["/usr/bin/isohybrid", "-u", "-m", iso])
+                subprocess.call(["isohybrid", "-u", "-m", iso])
             else:
-                subprocess.call(["/usr/bin/isohybrid", iso])
+                subprocess.call(["isohybrid", iso])
 
         self.__implant_md5sum(iso)
 
     def __implant_md5sum(self, iso):
         """Implant an isomd5sum."""
-        if os.path.exists("/usr/bin/implantisomd5"):
-            implantisomd5 = "/usr/bin/implantisomd5"
+        if subprocess.call(['type', 'implantisomd5']):
+            subprocess.call([implantisomd5, iso])
         elif os.path.exists("/usr/lib/anaconda-runtime/implantisomd5"):
             implantisomd5 = "/usr/lib/anaconda-runtime/implantisomd5"
+            subprocess.call([implantisomd5, iso])
         else:
             logging.warning("isomd5sum not installed; not setting up mediacheck")
             return
-
-        subprocess.call([implantisomd5, iso])
 
     def _stage_final_image(self):
         try:
@@ -988,7 +985,7 @@ image=/ppc/ppc32/vmlinuz
         shutil.copyfile(self._instroot + "/usr/lib/yaboot/yaboot",
                         isodir + "/ppc/chrp/yaboot")
 
-        subprocess.call(["/usr/sbin/addnote", isodir + "/ppc/chrp/yaboot"])
+        subprocess.call(["addnote", isodir + "/ppc/chrp/yaboot"])
 
         #
         # FIXME: ppc should support multiple kernels too...

--- a/tools/edit-livecd
+++ b/tools/edit-livecd
@@ -149,7 +149,7 @@ class LiveImageEditor(LiveImageCreator):
     def _get_fslabel(self):
         dev_null = os.open("/dev/null", os.O_WRONLY)
         try:
-            out = subprocess.Popen(["/sbin/e2label", self._image],
+            out = subprocess.Popen(["e2label", self._image],
                                    stdout = subprocess.PIPE,
                                    stderr = dev_null).communicate()[0]
 
@@ -425,7 +425,7 @@ class LiveImageEditor(LiveImageCreator):
             if os.path.exists(src):
                 os.rename(src, cfgf)
 
-        args = ['/bin/sed', '-i']
+        args = ['sed', '-i']
         if self._releasefile:
             args.append('-e')
             args.append('s/Welcome to .*/Welcome to ' + self._releasefile + '!/')
@@ -639,7 +639,7 @@ def parse_options(args):
 
 def get_fsvalue(filesystem, tag):
     dev_null = os.open('/dev/null', os.O_WRONLY)
-    args = ['/sbin/blkid', '-s', tag, '-o', 'value', filesystem]
+    args = ['blkid', '-s', tag, '-o', 'value', filesystem]
     try:
         fs_type = subprocess.Popen(args,
                                stdout=subprocess.PIPE,

--- a/tools/mkbackup
+++ b/tools/mkbackup
@@ -30,12 +30,12 @@ def main():
         
     def mkempty(bs, count):
         image = tempfile.mkstemp()
-        args = ("/bin/dd", "if=/dev/zero", "of=%s"%image, "bs=%s"%bs, "count=%s"%count)
+        args = ("dd", "if=/dev/zero", "of=%s"%image, "bs=%s"%bs, "count=%s"%count)
         execute(args)
         return image
 
     def dump(ent, file):
-        args = ("/sbin/dump", "-0", ent, "-f", file)
+        args = ("dump", "-0", ent, "-f", file)
         execute(args)
  
     def restore():
@@ -47,7 +47,7 @@ def main():
 
     def getrootents():
         ents = list()
-        args = ("/bin/df", "-lh")
+        args = ("df", "-lh")
         data = execute(args, needdata=True)
         lines = data.split('\n')
  

--- a/tools/mkbiarch
+++ b/tools/mkbiarch
@@ -25,9 +25,9 @@ def main():
             if not os.path.exists(dst):
                 os.makedir(dst)
             if options is None:
-                args = ("/bin/mount", src, dst)
+                args = ("mount", src, dst)
             else:
-                args = ("/bin/mount", options, src, dst)
+                args = ("mount", options, src, dst)
             rc = subprocess.call(args)
             return rc
         return
@@ -35,7 +35,7 @@ def main():
 
     def umount(src):
         if os.path.exists(src):
-                args = ("/bin/umount", src)
+                args = ("umount", src)
                 rc = subprocess.call(args)
                 return rc
         return
@@ -58,7 +58,7 @@ def main():
             tmp = tempfile.mkdtemp()
             return tmp
         else:
-            args = ("/bin/mkdir", "-p", dir)
+            args = ("mkdir", "-p", dir)
             rc = subprocess.call(args)
 
 
@@ -66,14 +66,14 @@ def main():
         if os.path.exists(src):
             if os.path.exists(dst):
                 if offset is None:
-                    args = ("/sbin/losetup", src, dst)
+                    args = ("losetup", src, dst)
                 else:
-                    args = ("/sbin/losetup", "-o", str(offset), src, dst)
+                    args = ("losetup", "-o", str(offset), src, dst)
                 rc = subprocess.call(args)
         return rc
 
     def lounset(device):
-        args = ("/sbin/losetup", "-d", device)
+        args = ("losetup", "-d", device)
         rc = subprocess.call(args) 
 
     def null():
@@ -81,16 +81,16 @@ def main():
         return fd
 
     def dd(file, target):
-        args = ("/bin/dd", "if=%s"%file, "of=%s"%target)
+        args = ("dd", "if=%s"%file, "of=%s"%target)
         rc = subprocess.call(args)
 
     def lo():
-        args = ("/sbin/losetup", "--find")
+        args = ("losetup", "--find")
         rc = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0].rstrip()
         return rc
 
     def lodev(file):
-        args = ("/sbin/losetup", "-j", file)
+        args = ("losetup", "-j", file)
         rc = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0].split(":")
         return rc[0]
 
@@ -98,7 +98,7 @@ def main():
     def mkimage(bs, count):
         tmp = tempfile.mkstemp()
         image = tmp[1]
-        args = ("/bin/dd", "if=/dev/zero",
+        args = ("dd", "if=/dev/zero",
                  "of=%s"%image, "bs=%s"%bs,
                  "count=%s"%count)
         rc = subprocess.call(args)
@@ -134,7 +134,7 @@ def main():
         disk.commit()
 
     def format(partition):
-        args = ("/sbin/mke2fs", "-j", partition)
+        args = ("mke2fs", "-j", partition)
         rc = subprocess.call(args)
 
     def mbr(target):
@@ -142,12 +142,12 @@ def main():
         dd(mbr, target)
 
     def getuuid(device):
-        args = ("/sbin/blkid", "-s", "UUID", "-o", "value", device)
+        args = ("blkid", "-s", "UUID", "-o", "value", device)
         rc = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0].rstrip()
         return rc
 
     def syslinux(multitmp, config, **args):
-        arg = ("/sbin/extlinux", "--install", multitmp + "/extlinux/")
+        arg = ("extlinux", "--install", multitmp + "/extlinux/")
         rc = subprocess.call(arg)
 
         content = """


### PR DESCRIPTION
Support the PATH environment variable for program calls.

This is untested for for kickstart.py, creator.py, live.py, edit-livecd, mkbackup, & mkbiarch.