### PR TITLE
livecd-iso-to-disk: Fix freespace determination for DVD installer.

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -1319,9 +1319,6 @@ checklivespace() {
     duTable=($(du -c -B 1M "$0" $sources 2> /dev/null || :))
     livesize=$((livesize + ${duTable[*]: -2:1} + 1))
 
-    freespace=($(df -B 1M $TGTDEV))
-    freespace=${freespace[*]: -3:1}
-
     tba=$((overlaysizemb + homesizemb + livesize + swapsizemb))
     if ((tba > freespace + tbd)); then
         needed=$((tba - freespace - tbd))
@@ -1344,6 +1341,9 @@ checklivespace() {
         exitclean
     fi
 }
+freespace=($(df -B 1M $TGTDEV))
+freespace=${freespace[*]: -3:1}
+
 [[ -z $skipcopy && live == $srctype ]] && checklivespace
 
 # Verify available space for DVD installer


### PR DESCRIPTION
In commit 7b0198d, the freespace determination was mistakenly
hidden from the DVD installer code path.

This should fix [rhbz #1445507](https://bugzilla.redhat.com/show_bug.cgi?id=1445507) & [livecd-tools/issues/61](https://github.com/livecd-tools/livecd-tools/issues/61)