### PR TITLE
Add --overlayfs, --copy-home, --copy-overlay options & allow multi installs to live booted devices

### DIFF
--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -6,7 +6,7 @@ livecd-iso-to-disk - Installs bootable Live images onto USB/SD storage devices.
 
 =head1 SYNOPSIS
 
-B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>] [--reset-overlay] [--home-size-mb <size>] [--copy-home] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
+B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>] [--copy-overlay] [--reset-overlay] [--home-size-mb <size>] [--copy-home] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
 
 Simplest
 
@@ -66,7 +66,7 @@ Creates a GUID partition table when --format is passed, and installs a hybrid Ex
 
 =item --skipcopy
 
-Skips the copying of the live image to the target device, bypassing the action of the --format, --overlay-size-mb, --home-size-mb, --copy-home, & --swap-size-mb options, if present on the command line. (The --skipcopy option may be used while testing the script, in order to avoid repeated and lengthy copy commands, or with --reset-mbr to repair the boot configuration files on a previously installed LiveOS device.)
+Skips the copying of the live image to the target device, bypassing the action of the --format, --overlay-size-mb, --copy-overlay, --home-size-mb, --copy-home, & --swap-size-mb options, if present on the command line. (The --skipcopy option may be used while testing the script, in order to avoid repeated and lengthy copy commands, or with --reset-mbr to repair the boot configuration files on a previously installed LiveOS device.)
 
 =item --force
 
@@ -146,6 +146,16 @@ The --overlayfs option requires an initial boot image based on dracut version 04
 
 Specifies creation of a filesystem overlay of <size> mebibytes (integer values only).  The overlay makes persistent storage available to the live operating system, if the operating system supports it.  The overlay holds a snapshot of changes to the root filesystem.  *Note well* that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent /LiveOS/overlay-<device_id> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to the restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the 'dmsetup status' command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, see --home-size-mb below.  The target storage device must have enough free space for the image and the overlay.  A maximum <size> of 4095 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
 
+=item --copy-overlay
+
+This option allows one to copy the persistent overlay from one live image to the new image.  Changes already made in the source image will be propagated to the new installation.
+
+=over 4
+
+B<WARNING:> User sensitive information such as password cookies and application or user data will be copied to the new image!  Scrub this information before using this option.
+
+=back
+
 =item --reset-overlay
 
 This option will reset the persistent overlay to an unallocated state.  This might be used if installing a new or refreshed image onto a device with an existing overlay, and avoids the writing of a large file on a vfat-formatted device.  This option also renames the overlay to match the current device filesystem label and UUID.
@@ -211,4 +221,3 @@ Copyright 2008-2010, 2017, Fedora Project and various contributors.  This is fre
 C<livecd-creator(1)>, project website C<http://fedoraproject.org/wiki/FedoraLiveCD>
 
 =cut
-

--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -20,11 +20,11 @@ To execute the script to completion, you will need to run it with root user perm
 
 =item <source>
 
-This may be the filesystem path to a LiveOS .iso image file, such as from a CD-ROM, DVD, or download.  It could also be the device node reference, the LiveOS-containing directory path, or the mount point for another LiveOS filesystem, including the currently booted LiveOS device, which is mounted at /run/initramfs/live.
+This may be the filesystem path to a LiveOS .iso image file, such as from a CD-ROM, DVD, or download.  It could also be the device node reference, the LiveOS-containing directory path, or the mount point for another LiveOS filesystem.  Entering 'live' for the <source> will source the currently booted LiveOS device.
 
 =item <target device>
 
-This should be the device partition name for the attached, target device, such as /dev/sdc1.  (Issue the df -Th command to get a listing of mounted partitions, so you can confirm the filesystem types, available space, and device names.)  Be careful to specify the correct device, or you may overwrite important data on another disk!
+This should be, or a link to, the device partition path for the attached, target device, such as /dev/sdc1.  (Issue the df -Th command to get a listing of mounted partitions, so you can confirm the filesystem types, available space, and device names.)  Be careful to specify the correct device, or you may overwrite important data on another disk!  For a multi boot installation to the currently booted device, enter 'live' as the target.
 
 =back
 
@@ -34,7 +34,7 @@ B<livecd-iso-to-disk> installs a Live CD/DVD/USB image (LiveOS) onto a USB/SD st
 
 Unless you request the --format option, installing an image does not destroy data outside of the LiveOS, syslinux, & EFI directories on your target device.  This allows one to maintain other files on the target disk outside of the LiveOS filesystem.
 
-LiveOS images employ embedded filesystems through the Device-mapper component of the Linux kernel.  The filesystems are embedded within files in the /LiveOS/ directory of the storage device.  The /LiveOS/squashfs.img file is the default, compressed filesystem containing one directory and the file /LiveOS/rootfs.img that contains the root filesystem for the distribution.  These are read-only filesystems that are usually fixed in size to within a few GiB of the size of the full root filesystem at build time.  At boot time, a Device-mapper snapshot with a default 0.5 GiB, in-memory, read-write overlay is created for the root filesystem.  Optionally, one may specify a fixed-size, persistent on disk overlay to hold changes to the root filesystem.  The build-time size of the root filesystem will limit the maximum size of the working root filesystem--even if supplied with an overlay file larger than the apparent free space on the root filesystem.  *Note well* that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent /LiveOS/overlay-<device_id> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to this restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the 'dmsetup status' command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, which will be saved in a fixed-size /LiveOS/home.img file.  This filesystem is encrypted by default.  (One may bypass encryption with the --unencrypted-home option.)  This filesystem is mounted on the /home directory of the root filesystem.  When its storage space is filled, out-of-space warnings will be issued by the operating system.
+LiveOS images employ embedded filesystems through the Device-mapper component of the Linux kernel.  The filesystems are embedded within files in the /LiveOS/ directory of the storage device.  The /LiveOS/squashfs.img file is the default, compressed filesystem containing one directory and the file /LiveOS/rootfs.img that contains the root filesystem for the distribution.  These are read-only filesystems that are usually fixed in size to within a few GiB of the size of the full root filesystem at build time.  At boot time, a Device-mapper snapshot with a sparse 32 GiB, in-memory, read-write overlay is created for the root filesystem.  Optionally, one may specify a fixed-size, persistent on disk overlay to hold changes to the root filesystem.  The build-time size of the root filesystem will limit the maximum size of the working root filesystem--even if supplied with an overlay file larger than the apparent free space on the root filesystem.  *Note well* that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent /LiveOS/overlay-<device_id> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to this restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the 'dmsetup status' command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, which will be saved in a fixed-size /LiveOS/home.img file.  This filesystem is encrypted by default.  (One may bypass encryption with the --unencrypted-home option.)  This filesystem is mounted on the /home directory of the root filesystem.  When its storage space is filled, out-of-space warnings will be issued by the operating system.
 
 =head1 OPTIONS
 
@@ -118,21 +118,21 @@ Specifies additional kernel arguments, <args>, that will be inserted into the sy
 
 =item --multi
 
-Used when installing multiple images, to signal configuration of boot files for the image in the --livedir <dir> parameter.
+Signals the boot configuration to accommodate multiple images on the target device.  Image and boot files will be installed under the --livedir <directory>.  SYSLINUX boot components from the installation host will always update those in the boot path of the target device.
 
 =item --livedir <dir>
 
-Used when multiple LiveOS images are installed on a device to designate the directory <dir> for the particular image.
+Designates the directory for installing the LiveOS image.  The default is /LiveOS.
 
-=item --compress   (default state for the original root filesystem)
+=item --compress    (default state for the original root filesystem)
 
 The default, compressed SquashFS filesystem image is copied on installation.  (This option has no effect if the source filesystem is already expanded.)
 
-=item --skipcompress   (default option when  --xo is specified)
+=item --skipcompress    (default option when  --xo is specified)
 
-Expands the source SquashFS.img on installation into the read-only /LiveOS/rootfs.img root filesystem image file.  This avoids the system overhead of decompression during use at the expense of storage space.
+Expands the source SquashFS.img on installation into the read-only /LiveOS/rootfs.img root filesystem image file.  This avoids the system overhead of decompression during use at the expense of storage space and bus I/O.
 
-=item --no-overlay   (effective only with skipcompress)
+=item --no-overlay    (effective only with --skipcompress or an uncompressed image)
 
 Installs a kernel option, rd.live.overlay=none, that signals the live boot process to create a writable, linear Device-mapper target for an uncompressed /LiveOS/rootfs.img filesystem image file.  Read-write by default (unless a kernel argument of rd.live.overlay.readonly is given) this configuration avoids the complications of using an overlay of fixed size for persistence when storage format and space allows.
 
@@ -152,7 +152,7 @@ Specifies creation of a home filesystem of <size> mebibytes (integer values only
 
 One must explicitly select this option in the case where there is an existing persistent home filesystem on the target device and the --home-size-mb <size> option is selected to create an empty, new home filesystem.  This prevents unwitting deletion of user files.
 
-=item --crypted-home   (default that only applies to new home-size-mb requests)
+=item --crypted-home    (default that only applies to new home-size-mb requests)
 
 Specifies the default option to encrypt a new persistent home filesystem when --home-size-mb <size> is specified.
 

--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -6,7 +6,7 @@ livecd-iso-to-disk - Installs bootable Live images onto USB/SD storage devices.
 
 =head1 SYNOPSIS
 
-B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlay-size-mb <size>] [--reset-overlay] [--home-size-mb <size>] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
+B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>] [--reset-overlay] [--home-size-mb <size>] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
 
 Simplest
 
@@ -135,6 +135,12 @@ Expands the source SquashFS.img on installation into the read-only /LiveOS/rootf
 =item --no-overlay    (effective only with --skipcompress or an uncompressed image)
 
 Installs a kernel option, rd.live.overlay=none, that signals the live boot process to create a writable, linear Device-mapper target for an uncompressed /LiveOS/rootfs.img filesystem image file.  Read-write by default (unless a kernel argument of rd.live.overlay.readonly is given) this configuration avoids the complications of using an overlay of fixed size for persistence when storage format and space allows.
+
+=item --overlayfs [temp]   (add --overlay-size-mb for persistence on vfat devices)
+
+Specifies the creation of an OverlayFS type overlay.  If the option is followed by 'temp', a temporary overlay will be used.  On vfat or msdos formatted devices, --overlay-size-mb <size> must also be provided for a persistent overlay.  OverlayFS overlays are directories of the files that have changed on the read-only root filesystem.  With non-vfat-formatted devices, the OverlayFS can extend the available root filesystem space up to the capacity of the Live USB device.
+
+The --overlayfs option requires an initial boot image based on dracut version 045 or greater to use the OverlayFS feature.  Lacking this, the device boots with a temporary Device-mapper overlay.
 
 =item --overlay-size-mb <size>
 

--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -6,7 +6,7 @@ livecd-iso-to-disk - Installs bootable Live images onto USB/SD storage devices.
 
 =head1 SYNOPSIS
 
-B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>] [--reset-overlay] [--home-size-mb <size>] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
+B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>] [--reset-overlay] [--home-size-mb <size>] [--copy-home] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
 
 Simplest
 
@@ -66,7 +66,7 @@ Creates a GUID partition table when --format is passed, and installs a hybrid Ex
 
 =item --skipcopy
 
-Skips the copying of the live image to the target device, bypassing the actions of the --format, --overlay-size-mb, --home-size-mb, & --swap-size-mb options, if present on the command line. (The --skipcopy option may be used while testing the script, in order to avoid repeated and lengthy copy commands, or with --reset-mbr to repair the boot configuration files on a previously installed LiveOS device.)
+Skips the copying of the live image to the target device, bypassing the action of the --format, --overlay-size-mb, --home-size-mb, --copy-home, & --swap-size-mb options, if present on the command line. (The --skipcopy option may be used while testing the script, in order to avoid repeated and lengthy copy commands, or with --reset-mbr to repair the boot configuration files on a previously installed LiveOS device.)
 
 =item --force
 
@@ -154,6 +154,16 @@ This option will reset the persistent overlay to an unallocated state.  This mig
 
 Specifies creation of a home filesystem of <size> mebibytes (integer values only).  A persistent home directory will be stored in the /LiveOS/home.img filesystem image file.  This filesystem is encrypted by default and not compressed  (one may bypass encryption with the --unencrypted-home option).  When the home filesystem storage space is full, one will get out-of-space warnings from the operating system.  The target storage device must have enough free space for the image, any overlay, and the home filesystem.  Note that the --delete-home option must also be selected to replace an existing persistent home with a new, empty one.  A maximum <size> of 4095 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
 
+=item --copy-home
+
+This option allows one to copy a persistent home.img filesystem from the source LiveOS image to the target image.  Changes already made in the source home directory will be propagated to the new image.
+
+=over 4
+
+B<WARNING:> User-sensitive information, such as password cookies and user and application data, will be copied to the new image! Scrub this information before using this option.
+
+=back
+
 =item --delete-home
 
 One must explicitly select this option in the case where there is an existing persistent home filesystem on the target device and the --home-size-mb <size> option is selected to create an empty, new home filesystem.  This prevents unwitting deletion of user files.
@@ -201,3 +211,4 @@ Copyright 2008-2010, 2017, Fedora Project and various contributors.  This is fre
 C<livecd-creator(1)>, project website C<http://fedoraproject.org/wiki/FedoraLiveCD>
 
 =cut
+


### PR DESCRIPTION
Enable configuration of OverlayFS overlays with dracut version 045
or greater based initial boot images.  (dracut version 046 has been released.)

Flash storage devices may have capacity for multiple live images.
Allow a live booted or sourced device to be both source and the
target for a live image installation. Provide an easy flag, 'live',
to request a live booted source or target.

Support replication of LiveOS images with --copy-home and --copy-overlay options.