### PR TITLE
livecd-iso-to-disk: Fix sed for kernelargs.

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -1579,8 +1579,8 @@ echo "Updating boot config file."
 sed -i -r "s/\<root=[^ ]*/root=live:$TGTLABEL/g
         s/\<rootfstype=[^ ]*\>/rootfstype=$TGTFS/" $BOOTCONFIG $BOOTCONFIG_EFI
 if [[ -n $kernelargs ]]; then
-    sed -i -r "s;\<initrd.\?\.img\>;& ${kernelargs} ;
-               s;\<vmlinuz.\?\>;& ${kernelargs} ;" $BOOTCONFIG $BOOTCONFIG_EFI
+    sed -i -r "s;=initrd.?\.img\>;& ${kernelargs} ;
+               s;/vmlinuz.?\>;& ${kernelargs} ;" $BOOTCONFIG $BOOTCONFIG_EFI
 fi
 if [[ $LIVEOS != LiveOS ]]; then
     sed -i -r "s;rd\.live\.image|liveimg;& rd.live.dir=$LIVEOS;


### PR DESCRIPTION
Distinguish $BOOTCONFIG from $BOOTCONFIG_EFI and don't use literal
/? here with extended regular expressions.

This should fix issue #72.