### PR TITLE
Use restorecon instead of setfiles for relabeling

### DIFF
--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -461,10 +461,10 @@ class SelinuxConfig(KickstartConfig):
         if ksselinux.selinux == ksconstants.SELINUX_DISABLED:
             return
 
-        if not os.path.exists(self.path("/sbin/setfiles")):
+        if not os.path.exists(self.path("/sbin/restorecon")):
             return
 
-        rc = self.call(["/sbin/setfiles", "-p", "-e", "/proc", "-e", "/sys", "-e", "/dev", selinux.selinux_file_context_path(), "/"])
+        rc = self.call(["/sbin/restorecon", "-p", "-e", "/proc", "-e", "/sys", "-e", "/dev", "-F", "-R", "/"])
         if rc:
             if ksselinux.selinux == ksconstants.SELINUX_ENFORCING:
                 raise errors.KickstartError("SELinux relabel failed.")


### PR DESCRIPTION
I'm currently using livecd-tools in a private project to make a custom live image for el7. With SELinux enabled, the build either aborts (enforcing mode) or is incorrect (permissive mode) due to setfiles aborting early due to 10 errors:

```
/etc/selinux/targeted/contexts/files/file_contexts: line 129 has invalid context system_u:object_r:gpfs_device_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 1459 has invalid context system_u:object_r:ganesha_var_log_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 1464 has invalid context system_u:object_r:ganesha_exec_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 1521 has invalid context system_u:object_r:ganesha_var_run_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 2370 has invalid context system_u:object_r:systemd_bootchart_var_run_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 2380 has invalid context system_u:object_r:ganesha_var_log_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 2693 has invalid context system_u:object_r:certmonger_unit_file_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 2723 has invalid context system_u:object_r:ipa_cert_t:s0
/etc/selinux/targeted/contexts/files/file_contexts: line 2999 has invalid context system_u:object_r:certmonger_unit_file_t:s0
Exiting after 10 errors.
Error creating Live CD : SELinux relabel failed.
```

From what I can tell, there are three possible resolutions:

1. Correct the SELinux policy (e.g., https://bugzilla.redhat.com/show_bug.cgi?id=984873).
Probably the correct solution, but it requires modifying a file that is not under my control, so is not a quick fix by any means. Moreover, the errors in the file_contexts file are irrelevant to the system I am building, so ignoring them is fine with me.
1. Pass in "-d" to setfiles to cause it to ignore the errors (see https://github.com/SELinuxProject/selinux/blob/master/policycoreutils/setfiles/setfiles.c#L63).
Pull request #22 is a similar thought, but is probably not the right implementation of this solution since you really need to pass "-d" into setfiles to get setfiles to actually finish labeling the system. I experimented with this solution, but passing in "-d" also dumps an overwhelming amount of debug information, and you still need to ignore the exit code, which leads to zero error trapping.
1. Switch livecd-tools to use restorecon (see https://github.com/SELinuxProject/selinux/blob/master/policycoreutils/setfiles/setfiles.c#L192 for the differences between setfiles and restorecon).
I experimented with this solution for my build because restorecon only validates contexts that are used and it seems to work fine for labeling my live image.

After looking at the source for fixfiles (https://github.com/SELinuxProject/selinux/blob/master/policycoreutils/scripts/fixfiles#L232), it seems that the preference is setfiles if it's being applied to an entire filesystem (and it ignores the exit code), but restorecon if it's being applied to a path. It's unclear why there is a distinction made.

I'm submitting a pull request to switch to restorecon because (IMHO) it seems to be the best choice.