### PR TITLE
livecd-iso-to-disk: Fix faulty --efi boot config code.

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -2189,7 +2189,8 @@ fi
 echo "Installing boot loader..."
 if [[ -n $efi ]]; then
     # replace the ia32 hack
-    if [[ -f $TGTMNT$T_EFI_BOOT/BOOT.conf ]]; then
+    if [[ -f $TGTMNT$T_EFI_BOOT/BOOT.conf ]] &&
+        [[ -f $TGTMNT$T_EFI_BOOT/BOOTia32.conf ]]; then
         cp -f $TGTMNT$T_EFI_BOOT/BOOTia32.conf $TGTMNT$T_EFI_BOOT/BOOT.conf
     fi
 fi


### PR DESCRIPTION
Test for file presence before attempting copy.
Fixes https://github.com/livecd-tools/livecd-tools/issues/82

I don't understand this section of code introduced almost 10 years ago with commit ceb818924b458b273293b17dd54b482b4581b528, but the patch allows the install script to complete and my test USB device booted properly.