### PR TITLE
util.py: Captured output from subprocesses should always be decoded.

### DIFF
--- a/imgcreate/util.py
+++ b/imgcreate/util.py
@@ -19,6 +19,7 @@
 
 import subprocess
 import logging
+import io
 
 def call(*popenargs, **kwargs):
     """
@@ -30,13 +31,14 @@ def call(*popenargs, **kwargs):
                          stderr=subprocess.STDOUT, **kwargs)
     rc = p.wait()
 
+    stdout = io.TextIOWrapper(p.stdout, encoding='utf-8')
+
     # Log output using logging module
     while True:
-        # FIXME choose a more appropriate buffer size
-        buf = p.stdout.read(4096)
+        buf = stdout.readline()
         if not buf:
             break
-        logging.debug("%s", buf)
+        logging.debug("%s", buf.rstrip())
 
     return rc
 


### PR DESCRIPTION
Since Python 3.6, Popen can accept an encoding to use for encoding
and decoding stdin, stderr, and stdout. Previously, call() did not
perform any decoding causes b'...' strings to be dumped into the
debug logs. Additionally, rcall() can be simplified slightly using
the same Popen feature.