### PR TITLE
livecd-iso-to-disk: Revert change that broke EFI/MBR hybrid booting

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -497,6 +497,8 @@ resetMBR() {
             echo 'Could not find gptmbr.bin (SYSLINUX).'
             exitclean
         fi
+        # Make the partition bootable from BIOS
+        run_parted --script $device set $partnum legacy_boot on
     else
         if [[ -f /usr/lib/syslinux/mbr.bin ]]; then
             cat /usr/lib/syslinux/mbr.bin > $device


### PR DESCRIPTION
In a previous commit (aec80bc61), the step that set legacy_boot on
the EFI System Partition was removed. The result of that was an
inability to boot the disk via legacy BIOS-based booting.