### PR TITLE
Fix two problems found in livecd-tools

### DIFF
--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -533,21 +533,6 @@ def get_image_fstype(ks, default = None):
             return p.fstype
     return default
 
-def get_modules(ks):
-    devices = []
-    if not hasattr(ks.handler.device, "deviceList"):
-        devices.append(ks.handler.device)
-    else:
-        devices.extend(ks.handler.device.deviceList)
-
-    modules = []
-    for device in devices:
-        if not device.moduleName:
-            continue
-        modules.extend(device.moduleName.split(":"))
-
-    return modules
-
 def get_timeout(ks, default = None):
     if not hasattr(ks.handler.bootloader, "timeout"):
         return default

--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -90,7 +90,6 @@ class LiveImageCreatorBase(LoopImageCreator):
                           "=mmc", "=pcmcia", "mptsas", "udf", "virtio_blk",
                           "virtio_pci", "virtio_scsi", "virtio_net", "virtio_mmio",
                           "virtio_balloon", "virtio-rng"]
-        self.__modules.extend(kickstart.get_modules(self.ks))
 
         self._isofstype = "iso9660"
         self.base_on = False

--- a/imgcreate/util.py
+++ b/imgcreate/util.py
@@ -30,12 +30,12 @@ def call(*popenargs, **kwargs):
     p = subprocess.Popen(*popenargs, stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT, **kwargs)
     rc = p.wait()
-
-    stdout = io.TextIOWrapper(p.stdout, encoding='utf-8')
+    fp = io.open(p.stdout.fileno(), mode="r", encoding="utf-8", closefd=False)
+    stdout = fp.read().split()
+    fp.close()
 
     # Log output using logging module
-    while True:
-        buf = stdout.readline()
+    for buf in stdout:
         if not buf:
             break
         logging.debug("%s", buf.rstrip())


### PR DESCRIPTION
While testing projects with the new pykickstart 3.9 release, I ran in to some issues with livecd-tools.  First, the get_modules() stuff in livecd-tools can be removed because that has been gone from pykickstart for a while.  Second, in imgcreate/util.py, I ran in to some problems with io.open and UTF-8 encoding.  Adjusted the way the function works a bit and things seem to be behaving fine.