### PR TITLE
imgcreate: Copy gcdia32.efi in __copy_efi_files if it exists (#95)

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -2,7 +2,7 @@
 # live.py : LiveImageCreator class for creating Live CD images
 #
 # Copyright 2007-2012, Red Hat, Inc.
-# Copyright 2016, Kevin Kofler
+# Copyright 2016-2018, Kevin Kofler
 # Copyright 2016, Neal Gompa
 # Copyright 2017, Fedora Project
 #
@@ -725,16 +725,18 @@ menu end
         """
         fail = False
         missing = []
-        files = [("/boot/efi/EFI/*/shim.efi", "/EFI/BOOT/BOOT%s.EFI" % (self.efiarch,)),
-                 ("/boot/efi/EFI/*/gcdx64.efi", "/EFI/BOOT/grubx64.efi"),
-                 ("/boot/efi/EFI/*/fonts/unicode.pf2", "/EFI/BOOT/fonts/"),
+        files = [("/boot/efi/EFI/*/shim.efi", "/EFI/BOOT/BOOT%s.EFI" % (self.efiarch,), True),
+                 ("/boot/efi/EFI/*/gcdx64.efi", "/EFI/BOOT/grubx64.efi", True),
+                 ("/boot/efi/EFI/*/gcdia32.efi", "/EFI/BOOT/grubia32.efi", False),
+                 ("/boot/efi/EFI/*/fonts/unicode.pf2", "/EFI/BOOT/fonts/", True),
                 ]
         makedirs(isodir+"/EFI/BOOT/fonts/")
-        for src, dest in files:
+        for src, dest, required in files:
             src_glob = glob.glob(self._instroot+src)
             if not src_glob:
-                missing.append("Missing EFI file (%s)" % (src,))
-                fail = True
+                if required:
+                    missing.append("Missing EFI file (%s)" % (src,))
+                    fail = True
             else:
                 shutil.copy(src_glob[0], isodir+dest)
         map(logging.error, missing)


### PR DESCRIPTION
imgcreate/live.py (__copy_efi_files): Add a required flag to the files.
Set it to True for the existing 3 files. But if set to False, just skip
the file if it is missing, and neither complain nor fail. Add
/boot/efi/EFI/*/gcdia32.efi to copy to /EFI/BOOT/grubia32.efi with
required=False.

Adds support for https://fedoraproject.org/wiki/Changes/32BitUefiSupport

Verified to do the right thing both with a Kannolo 27 x86_64 kickstart
(32-bit UEFI supported, gcdia32.efi gets copied) and with a Kannolo 26
x86_64 kickstart (32-bit UEFI not supported, gcdia32.efi is absent and
is skipped without producing an error).

Fixes #95.