### PR TITLE
Revert "Use restorecon instead of setfiles for relabeling"

### DIFF
--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -479,12 +479,12 @@ class SelinuxConfig(KickstartConfig):
             return
 
         try:
-            rc = subprocess.call(['restorecon', '-p', '-e', '/proc', '-e',
-                                  '/sys', '-e', '/dev', '-F', '-R', '/'],
-                                 preexec_fn=self.chroot)
+            rc = subprocess.call(['setfiles', '-p', '-e', '/proc',
+                                  '-e', '/dev',
+                                  selinux.selinux_file_context_path(), '/'])
         except OSError as e:
             if e.errno == errno.ENOENT:
-                logging.info('The restorecon command is not available.')
+                logging.info('The setfiles command is not available.')
                 return
         if rc:
             if ksselinux.selinux == ksconstants.SELINUX_ENFORCING:


### PR DESCRIPTION
restorecon doese not work inside the chroot, because there is no selinuxfs mounted on
/sys/fs/selinux, leading to no loaded selinux policy being loaded.
Setfiles bypasses the loaded policy, and just uses the installed policy.

This reverts commit 1c2307ce8b5150265f60afd7cf8a5749a1d26f9e.