### PR TITLE
Add support for RISC-V (riscv64)

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -1045,6 +1045,7 @@ elif arch in ("ppc64",):
     LiveImageCreator = ppc64LiveImageCreator
 elif arch.startswith(("arm", "aarch64")):
     LiveImageCreator = LiveImageCreatorBase
-
+elif arch in ("riscv64",):
+    LiveImageCreator = LiveImageCreatorBase
 else:
     raise CreatorError("Architecture not supported!")

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -2163,5 +2163,7 @@ elif arch in ("ppc64",):
     LiveImageCreator = ppc64LiveImageCreator
 elif arch.startswith(("arm", "aarch64")):
     LiveImageCreator = LiveImageCreatorBase
+elif arch in ("riscv64",):
+    LiveImageCreator = LiveImageCreatorBase
 else:
     raise CreatorError("Architecture not supported!")


### PR DESCRIPTION
This patch has been used successfully used in Fedora/RISC-V.

Signed-off-by: David Abdurachmanov <david.abdurachmanov@gmail.com>