### PR TITLE
DNF 3: workaround a bug with config values that are lists

### DIFF
--- a/imgcreate/dnfinst.py
+++ b/imgcreate/dnfinst.py
@@ -179,7 +179,10 @@ class DnfLiveCD(dnf.Base):
             # dnf 1
             repo = dnf.repo.Repo(name, cachedir = self.conf.cachedir)
         if url:
-            repo.baseurl.append(_varSubstitute(url))
+            # some overly clever trickery in dnf 3 prevents us just
+            # using repo.baseurl.append here:
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1595917
+            repo.baseurl = repo.baseurl + [_varSubstitute(url)]
         if mirrorlist:
             repo.mirrorlist = _varSubstitute(mirrorlist)
         repo.enable()


### PR DESCRIPTION
There's a bug / overly-clever-design flaw in DNF 3 that prevents
us appending to config values that appear to be lists, even
though lists should be mutable objects and this *ought* to work
(and did work in DNF 2):

https://bugzilla.redhat.com/show_bug.cgi?id=1595917

This works around it.

Signed-off-by: Adam Williamson <awilliam@redhat.com>