### PR TITLE
live.py: Fix unreported logging.error

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -724,7 +724,6 @@ menu end
               fonts/unicode.pf2
         """
         fail = False
-        missing = []
         files = [("/boot/efi/EFI/*/shim.efi", "/EFI/BOOT/BOOT%s.EFI" % (self.efiarch,), True),
                  ("/boot/efi/EFI/*/gcdx64.efi", "/EFI/BOOT/grubx64.efi", True),
                  ("/boot/efi/EFI/*/gcdia32.efi", "/EFI/BOOT/grubia32.efi", False),
@@ -735,11 +734,10 @@ menu end
             src_glob = glob.glob(self._instroot+src)
             if not src_glob:
                 if required:
-                    missing.append("Missing EFI file (%s)" % (src,))
+                    logging.error("Missing EFI file (%s)" % (src,))
                     fail = True
             else:
                 shutil.copy(src_glob[0], isodir+dest)
-        map(logging.error, missing)
         return fail
 
     def __get_basic_efi_config(self, **args):


### PR DESCRIPTION
With Python3, map() returns an iterator instead of a list as it does in Python2.
Avoid map() since we already have a for loop to process the collection of files.

This should fix Issue #94 (untested).