### PR TITLE
Handle dnf config option showing as tuple, not list, in DNF 3.6

### DIFF
--- a/imgcreate/dnfinst.py
+++ b/imgcreate/dnfinst.py
@@ -182,7 +182,10 @@ class DnfLiveCD(dnf.Base):
             # some overly clever trickery in dnf 3 prevents us just
             # using repo.baseurl.append here:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1595917
-            repo.baseurl = repo.baseurl + [_varSubstitute(url)]
+            # with the change to representing it as a tuple in DNF 3.6
+            # this '+= (tuple)' approach seems to work for DNF 2,
+            # 3.0-3.5 *and* 3.6
+            repo.baseurl += (_varSubstitute(url),)
         if mirrorlist:
             repo.mirrorlist = _varSubstitute(mirrorlist)
         repo.enable()


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1595917 again.
This is a follow-up to 2cbd239 - after I reported the bug,
upstream changed in DNF 3.6 to present these values as tuples
rather than lists, to indicate that they cannot be mutated. So
we can't add a list to the retrieved value, like we did before,
but using += (tuple) like this seems to work both in DNF 3.6
and in older DNFs.

Signed-off-by: Adam Williamson <awilliam@redhat.com>