### PR TITLE
livecd-iso-to-disk: Update test for 'gio' presence.

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -912,7 +912,7 @@ cp_p() {
 
 if type rsync >/dev/null 2>&1; then
     copyFile='rsync --inplace --8-bit-output --progress'
-elif type gvfs-copy >/dev/null 2>&1; then
+elif type gio >/dev/null 2>&1; then
     copyFile='gio copy -p'
 elif type strace >/dev/null 2>&1 && type awk >/dev/null 2>&1; then
     copyFile='cp_p'


### PR DESCRIPTION
Replace gvfs-copy with gio. Fixes RHBZ# 1665756, courtesy Bruce Jerrick.