### PR TITLE
Make --livedir & --multi handling more robust.

### DIFF
--- a/tools/editliveos
+++ b/tools/editliveos
@@ -773,9 +773,7 @@ class LiveImageEditor(LiveImageCreator):
             ops = 'ro'
         elif os.path.isdir(base_on):
             self.liveossrc = None
-            self.srcdir = os.path.join(base_on, 'LiveOS')
-            if not os.path.exists(self.srcdir):
-                self.srcdir = base_on
+            self.srcdir = base_on
         elif self.src_type == 'blk' and not self.liveossrc:
             self.liveossrc = DiskMount(RawDisk(None, base_on),
                              tempfile.mkdtemp(dir=mntdir, prefix='dev-'),
@@ -783,7 +781,7 @@ class LiveImageEditor(LiveImageCreator):
         if self.liveossrc:
             self.liveossrc.mount(dirmode=0o400)
             self.liveossrc.rmdir = True
-            self.srcdir = os.path.join(self.liveossrc.mountdir, 'LiveOS')
+            self.srcdir = self.liveossrc.mountdir
 
         liveosmnt = LiveImageMount(self.srcdir, tempfile.mkdtemp('-', 'LIM-',
                          mntdir), rootfsimg, overlay, ops=ops, dirmode=dirmode)

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -2,7 +2,7 @@
 # coding: utf-8
 #
 # Copyright 2009, Red Hat, Inc.
-# Copyright 2012-2018, Sugar Labs®
+# Copyright 2012-2019, Sugar Labs®
 # Forked from edit-livecd, written by Perry Myers <pmyers at redhat.com>
 #                                   & David Huff <dhuff at redhat.com>
 # Cloning code, OverlayFS, and filesystem editing added by Frederick Grose,
@@ -57,7 +57,7 @@ doc2 = '''
 
               Storage space requirements for stageing the build files are
               estimated by the script and compared to the space available in
-              the -t <TMPDIR> option (default=/var/tmp).
+              the -t <TMPDIR> option (default = /var/tmp).
 
               Invoke the --help option to learn about other optional features.
               '''
@@ -134,7 +134,7 @@ parser.add_argument('-n', '--name', help="Name for the new LiveOS image (don't"
                     ' the .iso will be named as NAME-arch-Ymd.HM\n'
                     "If the name contains the os separator '" + os.sep + "', "
                     'that\ncharacter will be replaced by the underscore_\n'
-                    'in the .iso file name and filesystem label.')
+                    'in the .iso file name and filesystem label.\n ')
 
 parser.add_argument('-o', '--output', metavar='PATH',
                     help='Specify a directory location for the new .iso file.'
@@ -197,9 +197,9 @@ parser.add_argument('-r', '--releasefile', metavar='PATH',
                     help='Specify release file/s for branding the build.\n'
                          'Denote multiple files as "path1, path2, ..."\n ')
 
-parser.add_argument('-b', '--builder', default=os.getenv('LOGNAME'),
+parser.add_argument('-b', '--builder', default=os.getenv('USERNAME'),
                     help='Specify the builder of a Remix.\n'
-                         'default = "' + os.getenv('LOGNAME') + '" (the '
+                         'default = "' + os.getenv('USERNAME') + '" (the '
                          'current system user)\n ')
 
 parser.add_argument('--clone', action='store_true', default=False,
@@ -335,26 +335,30 @@ parser.add_argument('-a', '--extra-kernel-args', dest='kernelargs',
 
 parser.add_argument('--extra-space-mb', type=int, default=2, metavar='SIZE',
                     help='Specify extra space in MiB to reserve for\n'
-                         'unexpected staging area needs.  Default = 2 MiB.\n ')
+                         'unexpected staging area needs.  default = 2 MiB\n ')
 
 parser.add_argument('--nocleanup', action='store_true', default=False,
-                    help='Skip cleanup of temporary files.')
+                    help='Skip cleanup of temporary files.\n ')
 
-parser.add_argument("--releasever", type=str, dest="releasever", 
+parser.add_argument('--releasever', type=str, dest='releasever', 
                     default=None, 
-                    help="Value to substitute for $releasever in kickstart repo urls")
+                    help='Value to substitute for $releasever in kickstart '
+                         'repo urls.\n ')
 
-parser.add_argument("--arch", type=str, dest="arch", 
+parser.add_argument('--arch', type=str, dest='arch', 
                     default=dnf.rpm.basearch(hawkey.detect_arch()), 
-                    help="Arch for the final image")
+                    help='Computer instruction set architecture for the '
+                         'final image.\n'
+                         'default = dnf.rpm.basearch(hawkey.detect_arch())\n ')
 
-parser.add_argument("-p", "--plugins", action="store_true", dest="plugins",
+parser.add_argument('-p', '--plugins', action='store_true', dest='plugins',
                     default=False, 
-                    help="Use DNF plugins during image creation")
+                    help='Use DNF plugins during image creation.\n ')
 
-parser.add_argument("--cacheonly", action="store_true", dest="cacheonly",
+parser.add_argument('--cacheonly', action='store_true', dest='cacheonly',
                     default=False,
-                    help="Work offline from cache, use together with --cache (default: False)")
+                    help='Work offline from cache, use together with --cache\n'
+                         'default = False')
 
 setup_logging(parser)
 
@@ -416,9 +420,9 @@ class LiveImageEditor(LiveImageCreator):
         """A string of file or directory paths to include in _brand().  This
         variable is later reused to hold the modified release name."""
 
-        self.builder = os.getenv('LOGNAME')
+        self.builder = os.getenv('USERNAME')
         """The name of the Remix builder for _branding.
-        Default = os.getenv('LOGNAME')"""
+        Default = os.getenv('USERNAME')"""
 
         self.compress_type = None
         """mksquashfs compressor to use. Use 'None' to force reading of the
@@ -612,6 +616,7 @@ class LiveImageEditor(LiveImageCreator):
             self.liveosmnt._LiveImageMount__create(ops='rw', dirmode=0o700)
             if isinstance(self.liveosmnt.livemount, OverlayFSMount):
                 self.src_type = 'embedded-OFS'
+                # src_type dir with no overlay also passes here.
             if self.liveosmnt.ovltype in ('', 'temp'):
                 self._overlay = self.liveosmnt.cowloop.lofile
 
@@ -1098,7 +1103,6 @@ class LiveImageEditor(LiveImageCreator):
 
         src, dst = srcmntdir, isodir
         if self.exclude_all:
-#            src = self.srcdir
             src = self.liveosdir
         if srcmntdir != self.srcdir:
             dst = os.path.join(isodir, 'LiveOS')
@@ -2409,7 +2413,7 @@ def main():
         if editor.liveosmnt:
             editor.liveosmnt.cleanup()
         editor.cleanup()
-        print('\nLiveOS edit has completed.')
+        print('\nLiveOS edit has ended.')
 
         h, m = divmod(time.time() - t0, 3600)
         m, s = divmod(m, 60)

--- a/tools/liveimage-mount
+++ b/tools/liveimage-mount
@@ -6,7 +6,7 @@
 #
 # Copyright 2011, Red Hat, Inc.
 # Copyright 2016, Neal Gompa
-# Copyright 2017-2018, Sugar Labs®
+# Copyright 2017-2019, Sugar Labs®
 #   Code for Live mounting an attached LiveOS device added by Frederick Grose,
 #   <fgrose at sugarlabs.org>
 #   Ported to Python 3 by Neal Gompa <ngompa13 at gmail.com>
@@ -589,12 +589,26 @@ def main():
             mount([liveos, liveosmnt], ops)
             unmount = 'yes'
 
-        for d in ('LiveOS', ''):
-            liveosdir = os.path.join(liveosmnt, d)
-            if not os.path.exists(liveosdir):
-                continue
-            else:
-                break
+        cfgf = os.path.join(liveosmnt, 'syslinux', 'syslinux.cfg')
+        if not os.path.exists(cfgf):
+            cfgf = os.path.join(liveosmnt, 'syslinux', 'extlinux.conf')
+        cmd = ['sed', '-n', '-r']
+        sedscript = r'''/^\s*label\s+linux/{n;n;n
+                        s/^\s*append\s+.*rd\.live\.dir=([^ ]*) .*/\1/p}'''
+        cmd.extend([sedscript, cfgf])
+        liveosdir, err, rc = rcall(cmd)
+        liveosdir = liveosdir.rstrip()
+        if liveosdir == os.path.basename(liveosmnt):
+            liveosdir = liveosmnt
+        elif liveosdir:
+            liveosdir = os.path.join(liveosmnt, liveosdir)
+        else:
+            for d in ('LiveOS', ''):
+                liveosdir = os.path.join(liveosmnt, d)
+                if not os.path.exists(liveosdir):
+                    continue
+                else:
+                    break
         liveosmnt = findmnt('-no TARGET -T', liveosdir)
 
         if roflag and os.access(liveosmnt, os.W_OK):
@@ -633,7 +647,6 @@ def main():
             print("\n\tNo %s was found on '%s'\n"
                   "\r\t  Exiting...\n%s" % (d, liveos, linkn[0]),
                   file=sys.stderr)
-            [os.rmdir(mp) for mp in remove_mp]
             sys_exit(1)
 
         overlayfs = None
@@ -657,7 +670,7 @@ def main():
                     remove_dir.append(workdir)
             else:
                 overlayloop = loop_setup(overlay, roflag)
-                call(['udevadm', 'settle'])
+                call(['udevadm', 'settle', '-E', overlayloop])
                 if lsblk('-ndo FSTYPE', overlayloop) not in (
                                                     '', 'DM_snapshot_cow'):
                     ovl_mp = tempfile.mkdtemp(prefix=Y + '-ovl-')


### PR DESCRIPTION
~~~~sh
Don't assume the default installation directory is /LiveOS; check
  the default menu label in the boot configuration file.
Escape special characters in livedir, title, & label strings for
  sed regex and replacement strings.
Save multi menu label blocks in the /syslinux configuration file
  for restoration on an overinstall of the default installation.
Handle the --force option properly with multi image installs.
Use the -E, --exit-if-exists option to udevadm settle in fs.py and
  liveimage-mount for the cow and overlay loop device.
Update copyright dates.
~~~~