### PR TITLE
imgcreate/fs: new compression option xz1m

### DIFF
--- a/imgcreate/fs.py
+++ b/imgcreate/fs.py
@@ -102,6 +102,8 @@ def mksquashfs(in_dir, out_img, compress_type, ops=[]):
 # Allow gzip to work for older versions of mksquashfs
     if not compress_type or compress_type == "gzip":
         args = ['mksquashfs', in_dir, out_img]
+    elif compress_type == "xz1m":
+        args = ['mksquashfs', in_dir, out_img, '-comp', 'xz', '-b', '1M', '-Xdict-size', '1M', '-no-recovery']
     else:
         args = ['mksquashfs', in_dir, out_img, '-comp', compress_type]
 
@@ -408,7 +410,7 @@ class LoopbackMount:
         self.losetup = False
         self.ops = ops
         self.dirmode = dirmode
-        
+
     def cleanup(self):
         self.diskmount.cleanup()
 
@@ -744,7 +746,7 @@ class DiskMount(Mount):
             ops = self.ops
         if isinstance(ops, list) and ('-r' in ops or 'ro' in ops):
             args.extend(['-o', 'ro'])
-        elif ops: 
+        elif ops:
             args.extend(['-o', ops])
 
         rc = call(args)
@@ -878,7 +880,7 @@ class OverlayFSMount(Mount):
         if self.cowmnt:
             self.cowmnt.unmount()
         self.imgmnt.unmount()
- 
+
         self.mounted = False
 
     def cleanup(self):
@@ -952,7 +954,7 @@ class BindChrootMount():
                 logging.info("lazy umount succeeded on %s" % self.dest)
                 print("lazy umount succeeded on %s" % self.dest,
                       file=sys.stdout)
- 
+
         self.mounted = False
 
     def cleanup(self):

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -69,6 +69,7 @@ def parse_options(args):
                            "(default xz needs a 2.6.38+ kernel, gzip works "
                            "with all kernels, lzo needs a 2.6.36+ kernel, lz4 "
                            "needs a 3.19+ kernel, lzma needs custom kernel.) "
+                           "Use xz1m for xz compression with 1M block size.",
                            "Set to 'None' to force read from base_on.",
                       default="xz")
     imgopt.add_option("", "--releasever", type="string", dest="releasever",


### PR DESCRIPTION
Lorax is getting more options in regard to compression which can dramatically shrink size of the live CD.

https://fedoraproject.org/wiki/Changes/OptimizeSquashFS

However in our pipeline, we are stuck with livecd-tools until we upgrade to EL8. My testing shows I am able to go from 342M to 296M just by passing this option, therefore I am proposing this patch to enable users like me to save space and bandwidth.