### PR TITLE
imgcreate: Allow more SquashFS compression options.

### DIFF
--- a/docs/livecd-creator.pod
+++ b/docs/livecd-creator.pod
@@ -10,7 +10,7 @@ B<livecd-creator> [OPTIONS]
 
 =head1 DESCRIPTION
 
-B<livecd-creator> creates live CD or DVD images(ISO images) from kickstart files. Kickstart files contain information about packages and configuration settings which are used to build the image.
+B<livecd-creator> creates live CD or DVD images (ISO images) from kickstart files. Kickstart files contain information about packages and configuration settings which are used to build the image.
 
 =head1 OPTIONS
 
@@ -42,29 +42,31 @@ Defines the file system label. The default is based on the configuration name.
 
 =item --title=TITLE
 
-Title used by syslinux.cfg file
+Title used by F<syslinux.cfg> file.
 
 =item --product=PRODUCT
 
-Product name used in syslinux.cfg boot stanzas and countdown
+Product name used in F<syslinux.cfg> boot stanzas and countdown.
 
 =item  -p, --plugins
 
-Use DNF plugins during image creation
+Use DNF plugins during image creation.
 
-=item --compression-type=COMPRESSOR
+=item --compression-type=COMPRESS_ARGS
 
 Specify a compressor recognized by mksquashfs.
-xz is the default and works with 2.6.38 and later kernels.
-gzip works with all kernels.
-lzo works with 2.6.36 and later kernels.
-lzma will only work with custom kernels.
-Set to 'None' to force reading the compressor used in BASE_ON.
-If gzip is used, the -comp option is not passed to mksquashfs to allow the use of older versions of mksquashfs.
+C<xz> is the default and works with 2.6.38 and later kernels.
+C<gzip> works with all kernels.
+C<lzo> works with 2.6.36 and later kernels.
+C<lzma> will only work with custom kernels.
+C<xz1m> is interpreted as C<"xz -b 1M -Xdict-size 1M -norecovery">.
+Set to C<None> to force reading the compressor used in BASE_ON.
+If C<gzip> is used, the -comp option is not passed to mksquashfs to allow the use of older versions of mksquashfs.
+Multiple arguments should be specified in one string, i.e., C<--compression-type "type arg1 arg2 ...">.
 
 =item --releasever=VER
 
-Set the value to substitute for $releasever in kickstart repo urls
+Set the value to substitute for $releasever in kickstart repo urls.
 
 =back
 
@@ -76,7 +78,7 @@ These options define directories used on your system for creating the live image
 
 =item -t TMPDIR, --tmpdir=TMPDIR
 
-defines the temporary directory to use. The default directory is /var/tmp.
+defines the temporary directory to use. The default directory is F</var/tmp>.
 
 =item --cache=CACHEDIR
 
@@ -84,35 +86,35 @@ Defines the cache directory to use (default: private cache).
 
 =item --cacheonly
 
-Work offline from cache, use together with --cache (default: False)
+Work offline from cache, use together with --cache (default: False).
 
 =item --nocleanup
 
-Skip cleanup of temporary files
+Skip cleanup of temporary files.
 
 =back
 
 =head1 DEBUGGING OPTIONS
 
-These options control the output of logging information during image creation
+These options control the output of logging information during image creation.
 
 =over 4
 
 =item -d, --debug
 
-Output debugging information
+Output debugging information.
 
 =item -v, --verbose
 
-Output verbose progress information
+Output verbose progress information.
 
 =item -q, --quiet
 
-Supress stdout
+Supress stdout.
 
 =item --logfile=FILE
 
-Save debug information to FILE
+Save debug information to FILE.
 
 =back
 
@@ -135,12 +137,12 @@ livecd-creator provides for some extensions to the repo commands similar
 to what DNF supports. The strings $arch, $basearch and $releasever
 are replaced with the system arch, basearch and release version respectively.
 When no --releasever is passed it defaults to the current system's version.
-The allows the use of repo commands such as the following:
+This allows the use of repo commands such as the following:
 
 repo --name=fedora --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 
 Note that in a chroot environment (like koji) the rpmdb is not available,
-so either don't use $releasever in that case, or pass --releasever=VER
+so either don't use $releasever in that case, or pass --releasever=VER.
 
 =head1 CONTRIBUTORS
 
@@ -148,14 +150,14 @@ David Zeuthen, Jeremy Katz, Douglas McClendon and a team of many other contribut
 
 =head1 BUGS
 
-Report bugs to the mailing list C<http://www.redhat.com/mailman/listinfo/fedora-livecd-list> or directly to Bugzilla C<http://bugzilla.redhat.com/bugzilla/> against the C<Fedora> product, and the C<livecd-tools> component.
+Report bugs to the mailing list L<http://www.redhat.com/mailman/listinfo/fedora-livecd-list> or directly to Bugzilla L<http://bugzilla.redhat.com/bugzilla/> against the C<Fedora> product, and the C<livecd-tools> component.
 
 =head1 COPYRIGHT
 
-Copyright (C) Fedora Project 2008,2009, and various contributors. This is free software. You may redistribute copies of it under the terms of the GNU General Public License C<http://www.gnu.org/licenses/gpl.html>. There is NO WARRANTY, to the extent permitted by law.
+Copyright (C) Fedora Project 2008,2009,2020, and various contributors. This is free software. You may redistribute copies of it under the terms of the GNU General Public License L<http://www.gnu.org/licenses/gpl.html>. There is NO WARRANTY, to the extent permitted by law.
 
 =head1 SEE ALSO
 
-C<livecd-iso-to-disk(1)>, project website C<http://fedoraproject.org/wiki/FedoraLiveCD>
+C<livecd-iso-to-disk(8)>, project website L<http://fedoraproject.org/wiki/FedoraLiveCD>
 
 =cut

--- a/imgcreate/fs.py
+++ b/imgcreate/fs.py
@@ -98,12 +98,14 @@ def squashfs_compression_type(sqfs_img):
                     break
     return compress_type
 
-def mksquashfs(in_dir, out_img, compress_type, ops=[]):
-# Allow gzip to work for older versions of mksquashfs
-    if not compress_type or compress_type == "gzip":
-        args = ['mksquashfs', in_dir, out_img]
-    else:
-        args = ['mksquashfs', in_dir, out_img, '-comp', compress_type]
+def mksquashfs(in_dir, out_img, compress_args, ops=[]):
+
+    args = ['mksquashfs', in_dir, out_img]
+    # Allow gzip to work for older versions of mksquashfs
+    if compress_args and compress_args != 'gzip':
+        if compress_args == 'xz1m':
+            compress_args = "xz -b 1M -Xdict-size 1M -no-recovery"
+        args += ['-comp'] + compress_args.split()
 
     if not sys.stdout.isatty():
         args.append('-no-progress')
@@ -150,7 +152,7 @@ def resize2fs(fs, size=None, minimal=False, ops=''):
 
 def e2fsck(fs):
     logging.info("Checking filesystem %s" % fs)
-    return call(['e2fsck', '-f', '-y', fs])
+    return call(['e2fsck', '-f', '-y', '-E', 'discard', fs])
 
 def get_dm_table(device):
     """Return the table for a Device-mapper device."""
@@ -408,7 +410,7 @@ class LoopbackMount:
         self.losetup = False
         self.ops = ops
         self.dirmode = dirmode
-        
+
     def cleanup(self):
         self.diskmount.cleanup()
 
@@ -744,7 +746,7 @@ class DiskMount(Mount):
             ops = self.ops
         if isinstance(ops, list) and ('-r' in ops or 'ro' in ops):
             args.extend(['-o', 'ro'])
-        elif ops: 
+        elif ops:
             args.extend(['-o', ops])
 
         rc = call(args)
@@ -878,7 +880,7 @@ class OverlayFSMount(Mount):
         if self.cowmnt:
             self.cowmnt.unmount()
         self.imgmnt.unmount()
- 
+
         self.mounted = False
 
     def cleanup(self):
@@ -952,7 +954,7 @@ class BindChrootMount():
                 logging.info("lazy umount succeeded on %s" % self.dest)
                 print("lazy umount succeeded on %s" % self.dest,
                       file=sys.stdout)
- 
+
         self.mounted = False
 
     def cleanup(self):

--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -62,8 +62,8 @@ class LiveImageCreatorBase(LoopImageCreator):
                                   cacheonly=cacheonly,
                                   docleanup=docleanup)
 
-        self.compress_type = "xz"
-        """mksquashfs compressor to use."""
+        self.compress_args = "xz"
+        """mksquashfs compressor arguments to use."""
 
         self.skip_compression = False
         """Controls whether to use squashfs to compress the image."""
@@ -173,12 +173,12 @@ class LiveImageCreatorBase(LoopImageCreator):
 
         squashloop = DiskMount(LoopbackDisk(squashimg, 0), self._mkdtemp(), "squashfs")
 
-        # 'self.compress_type = None' will force reading it from base_on.
-        if self.compress_type is None:
-            self.compress_type = squashfs_compression_type(squashimg)
-            if self.compress_type == 'undetermined':
+        # 'self.compress_args is None' will force reading it from base_on.
+        if self.compress_args is None:
+            self.compress_args = squashfs_compression_type(squashimg)
+            if self.compress_args == 'undetermined':
                 # Default to 'gzip' for compatibility with older versions.
-                self.compress_type = 'gzip'
+                self.compress_args = 'gzip'
         try:
             if not squashloop.disk.exists():
                 raise CreatorError("'%s' is not a valid live CD ISO : "
@@ -376,7 +376,7 @@ class LiveImageCreatorBase(LoopImageCreator):
                     os_image = os.path.dirname(self._image)
                 mksquashfs(os_image,
                            self.__isodir + "/LiveOS/squashfs.img",
-                           self.compress_type, ops)
+                           self.compress_args, ops)
                 self._LoopImageCreator__instloop.cleanup()
 
             self.__create_iso(self.__isodir)

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -2,7 +2,7 @@
 # coding: utf-8
 #
 # Copyright 2009, Red Hat, Inc.
-# Copyright 2012-2019, Sugar Labs®
+# Copyright 2012-2020, Sugar Labs®
 # Forked from edit-livecd, written by Perry Myers <pmyers at redhat.com>
 #                                   & David Huff <dhuff at redhat.com>
 # Cloning code, OverlayFS, and filesystem editing added by Frederick Grose,
@@ -93,7 +93,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [-e, --exclude <exclude, s>]
                         [-i, --include <include, s>]
                         [-u, --seclude <seclude, s>]
-                        [-r, --releasefile <releasefile, s>]
+                        [-r, --releasefile <releasefile s>]
                         [-b, --builder <builder>]
                         [-p, --plugins]
                         [--clone]
@@ -102,7 +102,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [--refresh-only]
                         [--skip-refresh]
                         [--skip-seclude]
-                        [-c, --compress-type <compression type>]
+                        [-c, --compress-type <compression arg s>]
                         [--compress]
                         [--releasever <value to substitute for $releasever in repo urls>]
                         [--arch <image arch>]
@@ -194,7 +194,7 @@ parser.add_argument('-u', '--seclude', dest='secludes', metavar='PATH',
 
 parser.add_argument('-r', '--releasefile', metavar='PATH',
                     help='Specify release file/s for branding the build.\n'
-                         'Denote multiple files as "path1, path2, ..."\n ')
+                         'Denote multiple files as "path1 path2 ..."\n ')
 
 parser.add_argument('-b', '--builder', default=os.getenv('USERNAME'),
                     help='Specify the builder of a Remix.\n'
@@ -289,10 +289,11 @@ parser.add_argument('--skip-refresh', action='store_true', default=False,
 parser.add_argument('--skip-seclude', action='store_true', default=False,
                     help='Specify no seclusion of specific user files.\n ')
 
-parser.add_argument('-c', '--compress-type', metavar='TYPE',
+parser.add_argument('-c', '--compress-type', metavar='ARGS',
                     help='Specify the compression type for SquashFS.\nThis '
                          'will override the current compression or lack\n'
-                         'thereof.\n ')
+                         'thereof.  Multiple arguments should be specified in\n'
+                         'one string, i.e., --compress-type "type arg1 arg2 ..."\n ')
 
 parser.add_argument('--compress', action='store_true', default=None,
                     help='Specify compression for the filesystem image.\n'
@@ -419,11 +420,13 @@ class LiveImageEditor(LiveImageCreator):
         """The name of the Remix builder for _branding.
         Default = os.getenv('USERNAME')"""
 
-        self.compress_type = None
+        self.compress_args = None
         """mksquashfs compressor to use. Use 'None' to force reading of the
-        source image, or enter a -p --compress_type value to override the
+        source image, or enter --compress-type "arg s" to override the
         current compression or lack thereof. Compression type options vary with
-        the version of the kernel and SquashFS used."""
+        the version of the kernel and SquashFS used. Multiple arguments should
+        be specified in one string, i.e., --compress-type "type arg1 arg2 ...".
+        """
 
         self._isofstype = "iso9660"
 
@@ -796,13 +799,13 @@ class LiveImageEditor(LiveImageCreator):
             squash_img = losetup('-nO BACK-FILE', self.squashloop)
             img = squash_img
         else:
-            self.compress_type = 'gzip'
-        # 'self.compress_type = None' will force reading it from base_on.
-        if self.compress_type is None:
-            self.compress_type = squashfs_compression_type(img)
-            if self.compress_type in ('undetermined', 'unknown'):
+            self.compress_args = 'gzip'
+        # 'self.compress_args = None' will force reading it from base_on.
+        if self.compress_args is None:
+            self.compress_args = squashfs_compression_type(img)
+            if self.compress_args in ('undetermined', 'unknown'):
                 # 'gzip' for compatibility with older versions.
-                self.compress_type = 'gzip'
+                self.compress_args = 'gzip'
 
         du_args = ['du', '-csxb', '--files0-from=-']
 
@@ -2297,8 +2300,8 @@ def main():
     editor.output = output
     editor.builder = args.builder
     if args.releasefile:
-        editor.releasefile = args.releasefile.split(', ')
-    editor.compress_type = args.compress_type
+        editor.releasefile = args.releasefile.split()
+    editor.compress_args = args.compress_type
     editor.refresh_uncompressed = args.refresh_uncompressed
     editor.skip_compression = args.skip_compression
     editor.compress = args.compress

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -64,12 +64,16 @@ def parse_options(args):
                            "This eliminates the intermediate LiveOS directory "
                            "and is suitable only for OverlayFS overlays.",
                       default=False)
-    imgopt.add_option("", "--compression-type", type="string", dest="compress_type",
-                      help="Compression type recognized by mksquashfs "
-                           "(default xz needs a 2.6.38+ kernel, gzip works "
-                           "with all kernels, lzo needs a 2.6.36+ kernel, lz4 "
-                           "needs a 3.19+ kernel, lzma needs custom kernel.) "
-                           "Set to 'None' to force read from base_on.",
+    imgopt.add_option("", "--compression-type", type="string", dest="compress_args",
+                      help="Compression type recognized by mksquashfs. "
+                           "(The default, xz, needs a 2.6.38+ kernel; gzip works "
+                           "with all kernels; lzo needs a 2.6.36+ kernel; lz4 "
+                           "needs a 3.19+ kernel; lzma needs custom kernel.) "
+                           'xz1m is interpreted as "xz -b 1M -Xdict-size 1M -norecovery". '
+                           "Set to 'None' to cause the program to read the compression "
+                           "type from the base_on image. "
+                           "Multiple arguments should be specified in "
+                           'one string, i.e., --compression-type "type arg1 arg2 ...".',
                       default="xz")
     imgopt.add_option("", "--releasever", type="string", dest="releasever",
                       default=None,
@@ -217,7 +221,7 @@ def main():
         logging.error(u"%s creation failed: %s", options.image_type, e)
         return 1
 
-    creator.compress_type = options.compress_type
+    creator.compress_args = options.compress_args
     creator.skip_compression = options.skip_compression
     creator.skip_minimize = options.skip_minimize
     if options.cachedir:


### PR DESCRIPTION
```sh
Enable greater control over image compression via mksquashfs
options.
Interpret xz1m as "xz -b 1M -Xdict-size 1M -norecovery".
Enter multiple compression arguments as one string, i.e.,
  --compression-type "type arg1 arg2 ...".
Update the documentation.
Use the extended option 'discard' for e2fsck of the root file
  system to reduce its size.
Also, eliminate some stray whitespace in fs.py, and
      use spaces to separate multiple arguments consistently
      in editliveos.
```

This is a more general alternative to PR #163.