### PR TITLE
BindChrootMount: Expand this class to include bind mounting of files.

### DIFF
--- a/tools/editliveos
+++ b/tools/editliveos
@@ -1333,10 +1333,6 @@ class LiveImageEditor(LiveImageCreator):
                 os.mknod(urandom, 0o666 | stat.S_IFCHR, os.makedev(1,9))
                 os.umask(origumask)
 
-            resolv = os.path.join(self._instroot, 'etc', 'resolv.conf')
-            if not os.path.exists(resolv):
-                open(resolv, 'a').close()
-
             bindmounts = [('/sys', None), ('/proc', None), ('/dev/pts', None),
                           ('/dev/shm', None), ('/run', None),
                           ('/etc/resolv.conf', None),

--- a/tools/liveimage-mount
+++ b/tools/liveimage-mount
@@ -793,9 +793,10 @@ def main():
             subprocess.check_call(['mount', '-t', 'tmpfs', 'tmpfs', tmpfs],
                                   stderr=sys.stderr)
             tmpfs = os.path.join(destmnt, 'etc', 'resolv.conf')
-            if os.path.lexists(tmpfs):
-                os.unlink(tmpfs)
-            os.symlink('/run/NetworkManager/resolv.conf', tmpfs)
+            os.makedirs(os.path.dirname(os.path.realpath(tmpfs)), exist_ok=True)
+            if not os.path.exists(tmpfs):
+                open(tmpfs, 'a').close()
+            mount(['--bind', os.path.join('/etc', 'resolv.conf'), tmpfs])
             if dnfcache:
                 mount(['--bind', dnfcache,
                        os.path.join(destmnt, 'var', 'cache', 'dnf')])


### PR DESCRIPTION
Also take advantage of the new (Python 3.2) exist_ok parameter of
os.makedirs() and apply these features to the bind mounting of
/etc/resolv.conf in editliveos and liveimage-mount.

Without these changes, those applications choked on the symbolic
link provided in the current version of Fedora 33 Workstation Live.