### PR TITLE
Pass package_types to dnf base group_install as tuple, not set

### DIFF
--- a/imgcreate/dnfinst.py
+++ b/imgcreate/dnfinst.py
@@ -129,7 +129,7 @@ class DnfLiveCD(dnf.Base):
         elif include == GROUP_ALL:
             package_types.add('optional')
         try:
-            self.group_install(grp.id, package_types, exclude=exclude)
+            self.group_install(grp.id, tuple(package_types), exclude=exclude)
         except dnf.exceptions.CompsError as e:
             # DNF raises this when it is already selected
             pass


### PR DESCRIPTION
I believe this is probably the cause of
https://bugzilla.redhat.com/show_bug.cgi?id=1886567 , which broke
Rawhide and F33 composes today. dnf itself seems to always pass
this as a list or a tuple. The dnf API docs say "`pkg_types` is a
sequence of strings determining the kinds of packages to be
installed"; according to Python docs, lists, tuples and range
types are "sequences", but sets are not, so technically we are
out of bounds here. I believe this worked before this dnf commit:
https://github.com/rpm-software-management/dnf/commit/4d991f61
and upstream *could* probably tweak things to accept sets again,
but it seems reasonable to fix it here.

Signed-off-by: Adam Williamson <awilliam@redhat.com>