### PR TITLE
Separate the errors for no ks specified and file not found

### DIFF
--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -127,8 +127,10 @@ def parse_options(args):
     if len(args):
         raise Usage("Extra arguments given")
 
-    if not options.kscfg or not os.path.exists(options.kscfg):
+    if not options.kscfg:
         raise Usage("Kickstart file must be provided")
+    if not os.path.exists(options.kscfg):
+        raise Usage("Kickstart file '%s' does not exist" % (options.kscfg))
     if options.base_on and not os.path.isfile(options.base_on):
         raise Usage("Image file '%s' does not exist" %(options.base_on,))
     if options.image_type == 'livecd':


### PR DESCRIPTION
It's more helpful to the user if we don't combine "you didn't give me a
kickstart file" and "you gave me a kickstart file, but it doesn't
exist".

In addition to giving separate error messages for the two cases, the
"you gave me a kickstart file, but it doesn't exist" says what kickstart
file it thinks it's looking for, which will help users catch syntax
errors.

Fixes #174