### PR TITLE
livecd-iso-to-disk & editliveos: Expand partitioning and filesystem support

### DIFF
--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -6,73 +6,117 @@ livecd-iso-to-disk - Installs bootable Live images onto USB/SD storage devices.
 
 =head1 SYNOPSIS
 
-B<livecd-iso-to-disk>  [--help] [--noverify] [--format] [--msdos] [--reset-mbr] [--efi] [--skipcopy] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <args>] [--multi] [--livedir <dir>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>] [--copy-overlay] [--reset-overlay] [--home-size-mb <size>] [--copy-home] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] <source> <target device>
-
-Simplest
+B<livecd-iso-to-disk>  [--format [<size>[,fstype[,blksz[,extra_attr,s]]]]] [--msdos] [--efi] [--noesp] [--reset-mbr] [--multi] [--livedir <directory>] [--skipcopy] [--noverify] [--force] [--xo] [--xo-no-home] [--timeout <duration>] [--totaltimeout <duration>] [--nobootmsg] [--nomenu] [--extra-kernel-args <arg s>] [--compress] [--skipcompress] [--no-overlay] [--overlayfs [temp]] [--overlay-size-mb <size>[,fstype[,blksz]]] [--copy-overlay] [--reset-overlay] [--home-size-mb <size>[,fstype,blksz]]] [--copy-home] [--delete-home] [--crypted-home] [--unencrypted-home] [--swap-size-mb <size>] [--updates <updates.img>] [--ks <kickstart>] [--label <label>] [--help]  F<<source>> F<<target partition/device>>
 
 The script may be run in simplest form with just the two arguments:
 
-B<livecd-iso-to-disk> <source> <target device>
+B<livecd-iso-to-disk> F<<source>> F<<target partition/device>>
 
-To execute the script to completion, you will need to run it with root user permissions.  SYSLINUX must be installed on the computer running this script.
+To execute the script to completion, you will need to run it with root user permissions.  Legacy booting of the installed image requires that SYSLINUX is installed on the host computer running this script.
 
 =over 4
 
 =item <source>
 
-This may be the filesystem path to a LiveOS .iso image file, such as from a CD-ROM, DVD, or download.  It could also be the device node reference, the LiveOS-containing directory path, or the mount point for another LiveOS filesystem.  Entering 'live' for the <source> will source the currently booted LiveOS device.
+This may be the filesystem path to a LiveOS .iso image file, such as from a CD-ROM, DVD, or download.  It could also be the device node reference, the LiveOS-containing directory path, or the mount point for another LiveOS filesystem.  Entering C<live> for the F<<source>> will source the currently booted LiveOS device.
 
-=item <target device>
+=item <target partition/device>
 
-This should be, or a link to, the device partition path for the attached, target device, such as /dev/sdc1.  (Issue the df -Th command to get a listing of mounted partitions, so you can confirm the filesystem types, available space, and device names.)  Be careful to specify the correct device, or you may overwrite important data on another disk!  For a multi boot installation to the currently booted device, enter 'live' as the target.
+This should be, or a link to, the device partition path for an attached, target device, such as F</dev/sdc1>.  A virtual block device, such as a loop device or a Device-mapper target may also be used.  (Issue the C<lsblk -pf> command to get a list of attached partitions, so you can confirm the device names, filesystem types, and available space.)  Be careful to specify the correct device, or you may overwrite important data on another disk!  If you request formatting with the --format option, enter only the base device path, such as F</dev/sdc>.  For a multi boot installation to the currently booted device, enter C<live> as the target.
 
 =back
 
 =head1 DESCRIPTION
 
-B<livecd-iso-to-disk> installs a Live CD/DVD/USB image (LiveOS) onto a USB/SD storage device (or any storage partition that will boot with a SYSLINUX bootloader).  The target storage device can then boot the installed operating system on systems that support booting via the USB or the SD interface.  The script requires a LiveOS source image and a target storage device.  A loop device backed by a file may also be targeted for virtual block device installation.  The source image may be either a LiveOS .iso file, or another reference to a LiveOS image, such as the device node for an attached device installed with a LiveOS image, its mount point, a loop device backed by a file containing an installed LiveOS image, or even the currently-running LiveOS image.  A pre-sized overlay file for persisting root filesystem changes may be included with the installed image.
+B<livecd-iso-to-disk> installs a Live CD/DVD/USB image (LiveOS) onto a USB/SD storage device.  The target storage device can then support booting the installed operating system on systems that support booting via the USB or the SD interface.  The script requires a LiveOS source image and a target storage device.  A loop device backed by a file may also be targeted for virtual block device installation.  Additionally, a Device-mapper target construct for block devices may be used.  If a Device-mapper mirror target is preconfigured, this target may be used to simultaneously target multiple physical devices.  The source image may be either a LiveOS .iso file, or another reference to a LiveOS image, such as the device node for an attached device installed with a LiveOS image, its mount point, a loop device backed by a file containing an installed LiveOS image, or even the currently-running LiveOS image.
 
-Unless you request the --format option, installing an image does not destroy data outside of the LiveOS, syslinux, & EFI directories on your target device.  This allows one to maintain other files on the target disk outside of the LiveOS filesystem.
+A pre-sized overlay file or a free-space-sized OverlayFS directory may be created for saving changes in the root filesystem of the installed image onto persistent storage media.
+
+Unless you request the --format option, installing an image does not destroy data outside of the F<LiveOS>, F<syslinux>, & F<EFI> directories on your target device.  This allows one to maintain other files on the target disk outside of the LiveOS filesystem.
 
 Multi image installations may be invoked interactively if the target device already contains a LiveOS image.
 
-LiveOS images employ embedded filesystems through the Device-mapper component of the Linux kernel.  The filesystems are embedded within files in the /LiveOS/ directory of the storage device.  The /LiveOS/squashfs.img file is the default, compressed filesystem containing one directory and the file /LiveOS/rootfs.img that contains the root filesystem for the distribution.  These are read-only filesystems that are usually fixed in size to within a few GiB of the size of the full root filesystem at build time.  At boot time, a Device-mapper snapshot with a sparse 32 GiB, in-memory, read-write overlay is created for the root filesystem.  Optionally, one may specify a fixed-size, persistent on disk overlay to hold changes to the root filesystem.  The build-time size of the root filesystem will limit the maximum size of the working root filesystem--even if supplied with an overlay file larger than the apparent free space on the root filesystem.  *Note well* that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent /LiveOS/overlay-<device_id> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to this restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the 'dmsetup status' command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, which will be saved in a fixed-size /LiveOS/home.img file.  This filesystem is encrypted by default.  (One may bypass encryption with the --unencrypted-home option.)  This filesystem is mounted on the /home directory of the root filesystem.  When its storage space is filled, out-of-space warnings will be issued by the operating system.
+LiveOS images employ embedded filesystems through the loop device, Device-mapper, or OverlayFS components of the Linux kernel.  The filesystems are embedded within files or directories in the F</LiveOS/> directory (by default) of the base filesystem on the storage device.  The F</LiveOS/squashfs.img> file is a SquashFS format compressed image, which by default contains one directory and file, F</LiveOS/rootfs.img>, that contains the root filesystem for the installed distribution image.  These both are read-only filesystems that are fixed in size usually to within a few GiB of the size of the full root filesystem at build time.  At boot time, either a Device-mapper snapshot with a temporary, 32 GiB, sparse, in-memory, read-write, overlay is created for the root filesystem, or an OverlayFS directory may be configured during bootup if configured on disk or by kernel command line options.  When one specifies a persistent, fixed-size, Device-mapper overlay to hold changes to the root filesystem, the build-time size of the root filesystem will limit the maximum size of the working root filesystemE<mdash>even if it is supplied with an overlay file larger than the apparent free space of the root filesystem.  Persistent OverlayFS directories avoid this limitation by creating a working union of two filesystems to serve as root filesystem.
+
+=over 4
+
+B<NOTE WELL:> Deletion of any of the original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in a Device-mapper overlay is allocated as needed.  If its overlay storage space is filled, the overlay will enter an 'Overflow' state while the root filesystem continues to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to this restriction.  If many or large changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the command C<dmsetup status> at a terminal or console of the running LiveOS image.  Consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, which will be saved in a fixed-size F</LiveOS/home.img> file.  This filesystem is encrypted by default.  (One may bypass encryption with the --unencrypted-home option.)  This filesystem is mounted on the F</home> directory of the root filesystem.  When its storage space is filled, out-of-space warnings will be issued by the operating system.
+
+=back
+
+When an OverlayFS overlay is requested (with the --overlayfs option), any changes to the root filesytem are saved in a directory space that is unioned by the kernel with the read-only root filesystem.  With non-vfat-formatted devices, the OverlayFS can extend the available root filesystem space up to the capacity of the Live USB/SD device.
 
 =head1 OPTIONS
 
 =over 4
 
-=item --help|-h|-?
+=item --format [sizemb[,fstype[,blksz[,extra_attr,s]]]]
 
-Displays usage information and exits.
+Partitions and formats the target device, creates an MS-DOS partition table or GUID partition table (GPT), if the --efi option is passed, creates 1 to 3 partitions, and invokes the --reset-mbr action.
+
+B<NOTE WELL:> All current disk content will be lost.
+
+=over 4
+
+Partition 1 is sized as requested or as available & fstype formatted.  fstype may be: ext[432](ext4 default)|fat|vfat|msdos|btrfs|xfs|f2fs  (extra_attr,s may be passed to f2fs formatting, for example, C<--format f2fs,-,extra_attr,compression>  Until GRUB's f2fs.mod is updated, any extra_attr will require booting with an EFI Boot Stub loader, such as the one from dracut triggered by the above format request.) Partition 1 is labelled as before or requested, flagged as bootable, and may allow an optional block size.
+
+Partition 2 is fat16 formatted and labelled 'EFI System Partition'.
+
+Partition 3 is HFS+ formatted and labelled as 'Mac'.
+
+=over 4
+
+Creation of partitions 2 & 3 is dependent on the presence of the files F</images/efiboot.img> & F</images/macboot.img> in the source.
+
+=back
+
+=back
+
+=item --msdos   (a legacy option. Use the --format msdos syntax instead.)
+
+Forces format to use the msdos (vfat) filesystem instead of ext4.
+
+=item --efi|--mactel
+
+Note: Even without this option, EFI components are always configured and loaded on the target disk if they are present on the source.
+
+When --efi is used with --format, a GUID partition table (GPT) and 1 to 3 partitions are created.  A hybrid Extensible Firmware Interface (EFI)/MBR bootloader is installed on the disk.
+
+This option is necessary for most Intel Macs.
+
+When --efi is used without --format but with --reset-mbr, it loads a hybrid (EFI)/MBR bootloader on the device.
+
+=item --noesp    (Used with --format.)
+
+Skip the formatting of an EFI System Partition and Mac boot partition.
+
+Note: Even with this option, EFI components are configured and loaded on the primary partition if they are present on the source.
+
+=item --reset-mbr|--resetmbr
+
+Sets the Master Boot Record (MBR) of the target storage device to the F<mbr.bin> or F<gptmbr.bin> file from the installation system's F<syslinux> directory.  This may be helpful in recovering a damaged or corrupted device.
+
+=item --multi
+
+Signals the boot configuration to accommodate multiple images on the target device.  Image and boot files will be installed under the --livedir F<<directory>>.  SYSLINUX boot components from the installation host will always update those in the boot path of the target device.  Boot files in the /EFI directories will be replaced by files from the source if they have newer modified times.
+
+=item --livedir F<<directory>>
+
+Designates the directory for installing the LiveOS image.  The default is F</LiveOS>.
+
+=item --skipcopy|--reconfig
+
+Skips the copying of the live image to the target device, bypassing the action of the --format, --overlay-size-mb, --copy-overlay, --home-size-mb, --copy-home, & --swap-size-mb options, if present on the command line. (The --skipcopy option is useful while testing the script, in order to avoid repeated and lengthy copy operations, or with --reset-mbr to repair or reinstall the boot configuration files on a previously installed LiveOS device.)
 
 =item --noverify
 
 Disables the image validation process that occurs before the image is copied from the original Live CD .iso image.  When this option is specified, the image is not verified before it is copied onto the target storage device.
 
-=item --format
-
-Formats the target device and creates an MS-DOS partition table (or GUID partition table, if the --efi option is passed).
-
-=item --msdos
-
-Forces format to use the msdos (vfat) filesystem instead of ext4.
-
-=item --reset-mbr|--resetmbr
-
-Sets the Master Boot Record (MBR) of the target storage device to the mbr.bin file from the installation system's syslinux directory.  This may be helpful in recovering a damaged or corrupted device.
-
-=item --efi|--mactel
-
-Creates a GUID partition table when --format is passed, and installs a hybrid Extensible Firmware Interface (EFI)/MBR bootloader on the disk.  This is necessary for most Intel Macs.
-
-=item --skipcopy
-
-Skips the copying of the live image to the target device, bypassing the action of the --format, --overlay-size-mb, --copy-overlay, --home-size-mb, --copy-home, & --swap-size-mb options, if present on the command line. (The --skipcopy option may be used while testing the script, in order to avoid repeated and lengthy copy commands, or with --reset-mbr to repair the boot configuration files on a previously installed LiveOS device.)
-
 =item --force
 
-This option allows the installation script to bypass a delete confirmation dialog in the event that a pre-existing LiveOS directory is found on the target device.
+This option forces an overwrite of the --livedir image, its syslinux directory, and associated files like home.img.  This allows the script
+to bypass a delete confirmation dialog in the event that a pre-existing LiveOS directory is found on the target device.  It also skips writing
+a new boot entry in the current system's UEFI boot manager for F2FS formatted target devices.
 
 =item --xo
 
@@ -86,7 +130,7 @@ Used to prepare an image for the OLPC XO-1 laptop with its compressed, JFFS2 fil
 
 =item --xo-no-home
 
-Used together with the --xo option to prepare an image for an OLPC XO laptop with the home directory on an SD card instead of the internal flash storage.
+Used together with the --xo option to prepare an image for an OLPC XO laptop with the F</home> directory on an SD card instead of the internal flash storage.
 
 =item --timeout <duration>
 
@@ -94,37 +138,29 @@ Modifies the bootloader's timeout value, which indicates how long to pause at th
 
 =over 4
 
-For SYSLINUX, a timeout unit is 1/10 second; the timeout is canceled when any key is pressed (the assumption being that the user will complete the command line); and a timeout of zero will disable the timeout completely.
+For SYSLINUX, a timeout unit is 1/10 second; the timeout is canceled when any key is pressed (the assumption being that the user will complete the command line); and a timeout of C<0> will disable the timeout completely.
 
-For EFI GRUB, the timeout unit is 1 second; timeout specifies the time to wait for keyboard input before booting the default menu entry.  A timeout of '0' means to boot the default entry immediately without displaying the menu; and a timeout of '-1' means to wait indefinitely.
+For EFI GRUB, the timeout unit is 1 second; timeout specifies the time to wait for keyboard input before booting the default menu entry.  A timeout of C<0> means to boot the default entry immediately without displaying the menu; and a timeout of C<-1> means to wait indefinitely.
 
 =back
 
-Enter a desired timeout value in 1/10 second units (or '-1') and the appropriate value will be supplied to the configuration file.  For immediate booting, enter '-0' to avoid the ambiguity between systems.  An entry of '-0' will result in an SYSLINUX setting of timeout 1 and totaltimeout 1. '0' or '-1' will result in an SYSLINUX setting of '0' (disable timeout, that is, wait indefinitely), but '0' for EFI GRUB will mean immediate boot of the default, while '-1' will mean EFI GRUB waits indefinitely for a user selection.
+Enter a desired timeout value in 1/10 second units (or C<-1>) and the appropriate value will be supplied to the configuration file.  For immediate booting, enter C<-0> to avoid the ambiguity between systems.  An entry of C<-0> will result in an SYSLINUX setting of timeout C<1> and totaltimeout C<1>. C<0> or C<-1> will result in an SYSLINUX setting of C<0> (disable timeout, that is, wait indefinitely), but C<0> for EFI GRUB will mean immediate boot of the default, while C<-1> will mean EFI GRUB waits indefinitely for a user selection.
 
 =item --totaltimeout <duration>
 
-Adds a SYSLINUX bootloader totaltimeout, which indicates how long to wait before booting automatically.  This is used to force an automatic boot.  This timeout cannot be canceled by the user.  Units are 1/10 s.  A totaltimeout of zero will disable the timeout completely.  (This setting is not available in EFI GRUB.)
+Adds a SYSLINUX bootloader totaltimeout, which indicates how long to wait before booting automatically.  This is used to force an automatic boot.  This timeout cannot be canceled by the user.  Units are 1/10 s.  A totaltimeout of C<0> will disable the timeout completely.  (This setting is not available in EFI GRUB.)
 
 =item --nobootmsg
 
-Do not display boot.msg, usually, \"Press the <ENTER> key to begin the installation process.\"
+Do not display F<boot.msg>, usually, "Press the <ENTER> key to begin the installation process."
 
 =item --nomenu
 
 Skip the boot menu, and automatically boot the 'linux' label item.
 
-=item --extra-kernel-args <args>
+=item --extra-kernel-args <arg s>
 
-Specifies additional kernel arguments, <args>, that will be inserted into the syslinux and EFI boot configurations.  Multiple arguments should be specified in one string, i.e., --extra-kernel-args "arg1 arg2 ..."
-
-=item --multi
-
-Signals the boot configuration to accommodate multiple images on the target device.  Image and boot files will be installed under the --livedir <directory>.  SYSLINUX boot components from the installation host will always update those in the boot path of the target device.
-
-=item --livedir <dir>
-
-Designates the directory for installing the LiveOS image.  The default is /LiveOS.
+Specifies additional kernel arguments, <arg s>, that will be inserted into the syslinux and EFI boot configurations.  Multiple arguments should be specified in one string, I<i.e.>, --extra-kernel-args "arg1 arg2 ..."
 
 =item --compress    (default state for the original root filesystem)
 
@@ -132,21 +168,23 @@ The default, compressed SquashFS filesystem image is copied on installation.  (T
 
 =item --skipcompress    (default option when  --xo is specified)
 
-Expands the source SquashFS.img on installation into the read-only /LiveOS/rootfs.img root filesystem image file.  This avoids the system overhead of decompression during use at the expense of storage space and bus I/O.
+Expands the source F<squashfs.img> on installation into the read-only F</LiveOS/rootfs.img> root filesystem image file.  This avoids the system overhead of decompression during use at the expense of storage space and bus I/O.
 
 =item --no-overlay    (effective only with --skipcompress or an uncompressed image)
 
-Installs a kernel option, rd.live.overlay=none, that signals the live boot process to create a writable, linear Device-mapper target for an uncompressed /LiveOS/rootfs.img filesystem image file.  Read-write by default (unless a kernel argument of rd.live.overlay.readonly is given) this configuration avoids the complications of using an overlay of fixed size for persistence when storage format and space allows.
+Installs a kernel option, C<rd.live.overlay=none>, that signals the live boot process to create a writable, linear Device-mapper target for an uncompressed F</LiveOS/rootfs.img> filesystem image file.  Read-write by default (unless a kernel argument of C<rd.live.overlay.readonly> is given) this configuration avoids the complications of using an overlay of fixed size for persistence when storage format and space allows.
 
 =item --overlayfs [temp]   (add --overlay-size-mb for persistence on vfat devices)
 
-Specifies the creation of an OverlayFS type overlay.  If the option is followed by 'temp', a temporary overlay will be used.  On vfat or msdos formatted devices, --overlay-size-mb <size> must also be provided for a persistent overlay.  OverlayFS overlays are directories of the files that have changed on the read-only root filesystem.  With non-vfat-formatted devices, the OverlayFS can extend the available root filesystem space up to the capacity of the Live USB device.
+Specifies the creation of an OverlayFS type overlay.  If the option is followed by C<temp>, a temporary overlay will be used.  On vfat or msdos formatted devices, --overlay-size-mb <size> must also be provided for a persistent overlay.  OverlayFS overlays are directories of the files that have changed on the read-only root filesystem.  With non-vfat-formatted devices, the OverlayFS can extend the available root filesystem space up to the capacity of the Live USB device.
 
 The --overlayfs option requires an initial boot image based on dracut version 045 or greater to use the OverlayFS feature.  Lacking this, the device boots with a temporary Device-mapper overlay.
 
-=item --overlay-size-mb <size>
+=item --overlay-size-mb <size>[,fstype[,blksz]]
 
-Specifies creation of a filesystem overlay of <size> mebibytes (integer values only).  The overlay makes persistent storage available to the live operating system, if the operating system supports it.  The overlay holds a snapshot of changes to the root filesystem.  *Note well* that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent /LiveOS/overlay-<device_id> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to the restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the 'dmsetup status' command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, see --home-size-mb below.  The target storage device must have enough free space for the image and the overlay.  A maximum <size> of 4095 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
+Specifies creation of a filesystem overlay of <size> mebibytes (integer values only).  [fstype] and [blksz] are relevant only for creating OverlayFS overlay filesystems on vfat-formatted primary devices.  An overlay makes persistent storage available to the live operating system, if permitted and installed on writable media.  The overlay holds a snapshot of changes to the root filesystem.
+
+B<Note well> that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent F</LiveOS/overlay-<device_id>> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to the restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the C<dmsetup status> command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, see --home-size-mb below.  The target storage device must have enough free space for the image and the overlay.  A maximum <size> of 4096 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
 
 =item --copy-overlay
 
@@ -162,13 +200,13 @@ B<WARNING:> User sensitive information such as password cookies and application 
 
 This option will reset the persistent overlay to an unallocated state.  This might be used if installing a new or refreshed image onto a device with an existing overlay, and avoids the writing of a large file on a vfat-formatted device.  This option also renames the overlay to match the current device filesystem label and UUID.
 
-=item --home-size-mb <size>
+=item --home-size-mb <size>[,fstype[,blksz]]
 
-Specifies creation of a home filesystem of <size> mebibytes (integer values only).  A persistent home directory will be stored in the /LiveOS/home.img filesystem image file.  This filesystem is encrypted by default and not compressed  (one may bypass encryption with the --unencrypted-home option).  When the home filesystem storage space is full, one will get out-of-space warnings from the operating system.  The target storage device must have enough free space for the image, any overlay, and the home filesystem.  Note that the --delete-home option must also be selected to replace an existing persistent home with a new, empty one.  A maximum <size> of 4095 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
+Specifies creation of a home filesystem of <size> mebibytes (integer values only).  A persistent home directory will be stored in the F</LiveOS/home.img> filesystem image file.  This filesystem is encrypted by default and not compressed  (one may bypass encryption with the --unencrypted-home option).  When the home filesystem storage space is full, one will get out-of-space warnings from the operating system.  The target storage device must have enough free space for the image, any overlay, and the home filesystem.  Note that the --delete-home option must also be selected to replace an existing persistent home with a new, empty one.  A maximum <size> of 4096 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
 
 =item --copy-home
 
-This option allows one to copy a persistent home.img filesystem from the source LiveOS image to the target image.  Changes already made in the source home directory will be propagated to the new image.
+This option allows one to copy a persistent F<home.img> filesystem from the source LiveOS image to the target image.  Changes already made in the source home directory will be propagated to the new image.
 
 =over 4
 
@@ -190,19 +228,23 @@ Prevents the default option to encrypt a new persistent home directory filesyste
 
 =item --swap-size-mb <size>
 
-Sets up a swap file of <size> mebibytes (integer values only) on the target device.  A maximum <size> of 4095 MiB is permitted for vfat-formatted devices.
+Sets up a swap file of <size> mebibytes (integer values only) on the target device.  A maximum <size> of 4096 MiB is permitted for vfat-formatted devices.
 
-=item --updates <updates.img>
+=item --updates F<<updates.img>>
 
-Setup a kernel command line argument, inst.updates, to point to an updates image on the device. Used by Anaconda for testing updates to an iso without needing to make a new iso. <updates.img> should be a path accessible to this script, which will be copied to the target device.
+Setup a kernel command line argument, C<inst.updates>, to point to an updates image on the device. Used by Anaconda for testing updates to an iso without needing to make a new iso. F<<updates.img>> should be a path accessible to this script, which will be copied to the target device.
 
 =item --ks <kickstart>
 
-Setup inst.ks to point to an kickstart file on the device. Use this for automating package installs on boot. <kickstart> should be a path accessible to this script, which will be copied to the target device.
+Setup C<inst.ks> to point to an kickstart file on the device. Use this for automating package installs on boot. F<<kickstart>> should be a path accessible to this script, which will be copied to the target device.
 
 =item --label <label>
 
-Specifies a specific filesystem label instead of default LIVE. Useful when you do unattended installs that pass a label to inst.ks
+Specifies a specific filesystem label instead of the default 'LIVE'. Useful when you do unattended installs that pass a label to F<inst.ks>.
+
+=item --help|-h|-?
+
+Displays usage information and exits.
 
 =back
 
@@ -212,14 +254,14 @@ David Zeuthen, Jeremy Katz, Douglas McClendon, Chris Curran and other contributo
 
 =head1 BUGS
 
-Report bugs to the mailing list C<http://admin.fedoraproject.org/mailman/listinfo/livecd> or directly to Bugzilla C<http://bugzilla.redhat.com/bugzilla/> against the C<Fedora> product, and the C<livecd-tools> component.
+Report bugs to the mailing list L<https://admin.fedoraproject.org/mailman/listinfo/livecd> or directly to Bugzilla L<https://bugzilla.redhat.com/bugzilla/> against the C<Fedora> product, and the C<livecd-tools> component.
 
 =head1 COPYRIGHT
 
-Copyright 2008-2010, 2017, Fedora Project and various contributors.  This is free software. You may redistribute copies of it under the terms of the GNU General Public License C<http://www.gnu.org/licenses/gpl.html>. There is NO WARRANTY, to the extent permitted by law.
+Copyright 2008-2010, 2017-2021, Fedora Project and various contributors.  This is free software. You may redistribute copies of it under the terms of the GNU General Public License L<https://www.gnu.org/licenses/gpl.html>. There is NO WARRANTY, to the extent permitted by law.
 
 =head1 SEE ALSO
 
-C<livecd-creator(1)>, project website C<http://fedoraproject.org/wiki/FedoraLiveCD>
+C<livecd-creator(8)>, project website L<https://fedoraproject.org/wiki/FedoraLiveCD>
 
 =cut

--- a/imgcreate/fs.py
+++ b/imgcreate/fs.py
@@ -4,7 +4,7 @@
 #
 # Copyright 2007, Red Hat, Inc.
 # Copyright 2016, Neal Gompa
-# Copyright 2017-2019, Sugar Labs®
+# Copyright 2017-2021, Sugar Labs®
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 
 import os
 import os.path
@@ -30,6 +27,7 @@ import stat
 import shutil
 import subprocess
 import random
+import resource
 import logging
 import tempfile
 import time
@@ -103,7 +101,7 @@ def mksquashfs(in_dir, out_img, compress_args, ops=[]):
     args = ['mksquashfs', in_dir, out_img]
     # Allow gzip to work for older versions of mksquashfs
     if compress_args and compress_args != 'gzip':
-        if compress_args == 'xz1m':
+        if compress_args in ('xz1m', 'xz1M'):
             compress_args = "xz -b 1M -Xdict-size 1M -no-recovery"
         args += ['-comp'] + compress_args.split()
 
@@ -123,36 +121,154 @@ def mksquashfs(in_dir, out_img, compress_args, ops=[]):
         raise SquashfsError("'%s' exited with error (%d)" %
                             (' '.join(args), ret))
 
-def resize2fs(fs, size=None, minimal=False, ops=''):
+def checkfsblksz(fstype, size, use=None, fssize=None):
+
+    if fstype in ('fat', 'vfat', 'msdos'):
+        if size not in (512, 1024, 2048, 4096, 8192, 16384, 32768):
+            raise CreatorError('\nERROR:  < %s > is not a valid sector size '
+            'for FAT.\n\n\t512, 1024, 2048, 4096, 8192, 16384, & 32768 bytes '
+            'may be specified.\n\n\tValues larger than 4096 bytes do not '
+            'conform to the FAT file system\n\tspecification and may not '
+            'work everywhere.  Please correct this.\n\n' % size)
+        if use == 'dev' and size > 512:
+            input('''\n
+            WARNING:
+            Block sizes greater that 512 bytes on vfat partitions
+            are not suitable for SYSLINUX bootable partitions.
+            Press Ctrl C to abort or Enter to continue...\n\n''')
+        elif use == 'home':
+            input('''\n
+            WARNING:
+            Using a FAT filesystem for a GNU/Linux home directory
+            will cause many core applications and services to fail
+            do to its limitations in managing access rights.
+            Press Ctrl C to abort, or Enter to continue...\n\n''')
+
+    elif fstype in ('ext4', 'ext3', 'ext2'):
+        if size not in (1024, -1024, 2048, -2048, 4096, -4096):
+            raise CreatorError('''\n
+            ERROR: < %s > is not a valid block size for the %s fs.
+            1024, 2048, & 4096 bytes may be specified.\n\n''' % (size, fstype))
+
+    elif fstype == 'f2fs' and size != 4096:
+        raise CreatorError('''\n
+        ERROR:  F2FS does not support block sizes other than
+                4096 bytes.\n\n''')
+
+    elif fstype == 'xfs':
+        if size not in (512, 4096, 65536):
+            raise CreatorError('''\n
+            ERROR: < %s > is not a valid block size for the xfs fs.
+            512, 4096, and 65536 bytes may be specified.\n\n''' % size)
+
+        ps = resource.getpagesize()
+        if use == 'dev' and size > ps:
+            imput('''\n
+            WARNING:
+            Partitions with block sizes greater than the
+            pagesize, %s bytes, may not be mountable by
+            default on this system.
+            Press Ctrl C to abort, or Enter to continue...\n\n''' % size)
+
+    elif fstype == 'btrfs':
+        if fssize < 16:
+            if size != 4:
+                raise CreatorError('''\n
+                ERROR:  Illegal node size < %s KiB> for btrfs mixed block
+                group filesystems.  Mixed block groups are suggested
+                for filesystems smaller than 16 GiB.  A node size of
+                4 Kibytes is required for mixed block groups.\n\n''' % size)
+        elif size not in (16, 32, 64):
+            raise CreatorError('''\n
+            ERROR:  < %s KiB> is not a valid node size for btrfs.
+            16 KiB is the default; 32 KiB is allowed; 64 KiB is the maximum.
+            ''' % size)
+
+
+def resizefs(fs, fstype, size=None, blksz=None, minimal=False, ops=''):
+
+    fsmnt = None
+    def mountfs(fs):
+        fsmp = tempfile.mkdtemp(dir='/run/media')
+        fsmnt = LoopbackMount(fs, fsmp)
+        fsmnt.mount()
+        return fsmnt
+
     if minimal and size is not None:
         raise ResizeError("Can't specify both minimal and a size for resize!")
 
-    args = ['resize2fs', '-p', fs]
-    if ops == 'nocheck':
-        args.append('-f')
-    else:
-        e2fsck(fs)
+    if ops != 'nocheck':
+        fsck(fs, fstype)
+
+    if fstype.startswith('ext'):
+        args = ['resize2fs', '-p', fs]
+        if minimal:
+            args.append('-M')
+        elif size:
+            args.append('%sK' %(size // 1024,))
+        if ops == 'nocheck':
+            args.append('-f')
+
+    elif fstype == 'f2fs':
+        args = ['resize.f2fs', fs]
+        if size:
+            args.extend(['-t', '%s' %(size // 512), '-d', '1'])
+
+    elif fstype == 'xfs':
+        # xfs_growfs requires that the filesystem be mounted.
+        fsmnt = mountfs(fs)
+        args = ['xfs_growfs', fsmnt.diskmount.mountdir]
+        if size:
+            args.extend(['-D', '%s' %(size // blksz)])
+
+    elif fstype == 'btrfs':
+        fsmnt = mountfs(fs)
+        if minimal:
+            args = ['btrfs', 'inspect-internal', 'min-dev-size',
+                    fsmnt.diskmount.mountdir]
+            min = rcall(args)[0].split()[0]
+            print('min-dev-size: ', min, ' bytes')
+            size = min
+
+        args = ['btrfs', 'filesystem', 'resize', str(size),
+                fsmnt.diskmount.mountdir]
 
     logging.info('resizing %s' % (fs,))
-    if minimal:
-        args.append('-M')
-    elif size:
-        args.append('%sK' %(size // 1024,))
     ret = call(args)
     if ret != 0:
-        raise ResizeError("resize2fs returned an error (%d)!" % (ret,))
+        raise ResizeError("resizefs returned an error (%d)!" % (ret,))
+
+    if fsmnt:
+        fsmnt.cleanup()
 
     if ops != 'nocheck':
-        ret = e2fsck(fs)
+        ret = fsck(fs, fstype)
         if ret != 0:
             raise ResizeError("fsck after resize returned an error (%d)!" %
                               (ret,))
 
     return 0
 
-def e2fsck(fs):
+def fsck(fs, fstype):
     logging.info("Checking filesystem %s" % fs)
-    return call(['e2fsck', '-f', '-y', '-E', 'discard', fs])
+
+    if fstype.startswith('ext'):
+        args = ['e2fsck', '-f', '-y', '-E', 'discard']
+    elif fstype == 'f2fs':
+        args = ['fsck.f2fs', '-f']
+    elif fstype in ('vfat', 'msdos'):
+        args = ['fsck.fat', '-avVw']
+    elif fstype == 'btrfs':
+        args = ['btrfs', 'check', '-p', '--repair', '--force']
+    elif fstype == 'xfs':
+        args = ['xfs_repair', '-fv']
+    elif fstype == 'hfsplus':
+        args = ['fsck.hfsplus', '-yfp']
+
+    out, err, rc = rcall(args + [fs])
+    print(out, '\n', err, '\n', rc)
+
+    return rc
 
 def get_dm_table(device):
     """Return the table for a Device-mapper device."""
@@ -390,7 +506,7 @@ def mirror_fs(fs_dev, dm_node, imgsize, mirloops, mirname):
         print('/\b', end='')
         sys.stdout.flush()
         time.sleep(.5)
-        print('-\b', end='')
+        print('\u2014\b', end='')
         sys.stdout.flush()
         time.sleep(.5)
         print('\\\b', end='')
@@ -494,8 +610,8 @@ class SparseExtLoopbackMount(SparseLoopbackMount):
     def mount(self, ops='', dirmode=None):
         self.diskmount.mount(ops, dirmode)
 
-    def __fsck(self):
-        self.extdiskmount.__fsck()
+    def __fsck(self, fstype):
+        self.extdiskmount.__fsck(self.fstype)
 
     def __get_size_from_filesystem(self):
         return self.diskmount.__get_size_from_filesystem()
@@ -554,10 +670,11 @@ class RawDisk(Disk):
 
 class LoopbackDisk(Disk):
     """A Disk backed by a file via the loop module."""
-    def __init__(self, lofile, size, ops='', dirmode=None):
+    def __init__(self, lofile, size, ops='', fstype=None, dirmode=None):
         Disk.__init__(self, size)
         self.lofile = lofile
         self.ops = ops
+        self.fstype = fstype
         self.dirmode = dirmode
 
     def fixed(self):
@@ -593,6 +710,8 @@ class LoopbackDisk(Disk):
             raise MountError("Failed to allocate loop device for '%s'" %
                              self.lofile)
         self.device = device
+        call(['udevadm', 'settle'])
+        self.fstype = lsblk('-ndo FSTYPE', device)
 
     def cleanup(self):
         if self.device is None:
@@ -968,7 +1087,9 @@ class BindChrootMount():
 
 
 class ExtDiskMount(DiskMount):
-    """A DiskMount object that can format/resize ext[234] filesystems."""
+    """A Extensible DiskMount object that can format and resize ext[234], xfs,
+    btrfs, and F2FS filesystems. (xfs and F2FS can only be enlarged.)
+    """
     def __init__(self, disk, mountdir, fstype, blocksize, fslabel,
                  rmmountdir=True, ops='', dirmode=None):
         DiskMount.__init__(self, disk, mountdir, fstype, rmmountdir, ops=ops,
@@ -983,14 +1104,20 @@ class ExtDiskMount(DiskMount):
         call(['wipefs', '-a', self.disk.device])
         args = ['mkfs.' + self.fstype]
         if self.fstype.startswith('ext'):
-            args = args + ['-F', '-L', self.fslabel, '-m', '1', '-b',
-                           str(self.blocksize)]
+            args += ['-F', '-L', self.fslabel[0:16], '-m', '1', '-b',
+                     str(self.blocksize)]
         elif self.fstype == 'xfs':
-            args = args + ['-L', self.fslabel[0:10], '-b', 'size=%s' %
-                           str(self.blocksize)]
+            args += ['-L', self.fslabel[0:12], '-b', 'size=%s' %
+                     str(self.blocksize)]
         elif self.fstype == 'btrfs':
-            args = args + ['-L', self.fslabel]
-        args = args + [self.disk.device]
+            args += ['-L', self.fslabel[0:255]]
+        elif self.fstype == 'f2fs':
+            args += ['-f', '-l', self.fslabel[0:512]]
+            ver = rcall(['mkfs.f2fs', '-V'])[0].split()[2].strip('()').replace('-', '')
+            if int(ver) >= 20200824:
+                # ver 1.14.0 (2020-08-24)
+                args += ['-O', 'extra_attr,compression']
+        args += [self.disk.device]
         logging.info("Formating args: %s" % args)
         rc = call(args)
 
@@ -1013,9 +1140,9 @@ class ExtDiskMount(DiskMount):
         if size > current_size:
             self.disk.expand(size=size)
 
-        if self.fstype.startswith('ext'):
-            resize2fs(self.disk.lofile, size, ops=ops)
-        elif size < current_size:
+        resizefs(self.disk.lofile, self.fstype, size, blksz=self.blocksize,
+                 ops=ops)
+        if size < current_size:
             self.disk.truncate(size=size)
         return size
 
@@ -1039,8 +1166,8 @@ class ExtDiskMount(DiskMount):
         self.__create(ops)
         DiskMount.mount(self, ops, dirmode)
 
-    def __fsck(self):
-        return e2fsck(self.disk.lofile)
+    def __fsck(self, fstype):
+        return fsck(self.disk.lofile, self.fstype)
         return rc
 
     def __get_size_from_filesystem(self):
@@ -1052,17 +1179,39 @@ class ExtDiskMount(DiskMount):
             raise KeyError("Failed to find field '%s' in output" % field)
 
         dev_null = os.open('/dev/null', os.O_WRONLY)
+        if self.fstype.startswith('ext'):
+            args = ['dumpe2fs', '-h']
+        elif self.fstype == 'f2fs':
+            args = ['dump.f2fs']
+        elif self.fstype == 'xfs':
+            args = ['xfs_info']
+        elif self.fstype == 'btrfs':
+            self.mount()
+            args = ['btrfs', 'filesystem', 'usage', '-b', self.mountdir]
+
+        if not self.fstype == 'btrfs':
+            args += [self.disk.lofile]
         try:
-            out = subprocess.Popen(['dumpe2fs', '-h', self.disk.lofile],
+            out = subprocess.Popen(args,
                                    stdout=subprocess.PIPE,
                                    stderr=dev_null).communicate()[0]
         finally:
             os.close(dev_null)
 
-        return int(parse_field(out, b'Block count:')) * self.blocksize
+        if self.fstype.startswith('ext'):
+            return int(parse_field(out, b'Block count:')) * self.blocksize
+        elif self.fstype == 'f2fs':
+            args = parse_field(out, b'Info: total FS sectors = ')
+            return int(args.split()[0]) * 512
+        elif self.fstype == 'xfs':
+            args = parse_field(out, b'data     =                       bsize=')
+            return int(args.split()[0]) * int(args.split(b'=')[1].split(b',')[0])
+        elif self.fstype == 'btrfs':
+            self.unmount()
+            return int(parse_field(out, b'    Device size:'))
 
     def __resize_to_minimal(self, ops=''):
-        resize2fs(self.disk.lofile, minimal=True, ops=ops)
+        resizefs(self.disk.lofile, self.fstype, minimal=True, ops=ops)
         return self.__get_size_from_filesystem()
 
     def resparse(self, size=None, ops=None):
@@ -1155,7 +1304,7 @@ class DeviceMapperSnapshot(object):
             return
 
         self.imgloop.create(ops=ops)
-        self.cowloop.create(ops=ops)
+        self.cowloop.create()
 
         self.DeviceMapperTarget__name = self.__name = 'imgcreate-%d-%d' % (
             os.getpid(), random.randint(0, 2**16))
@@ -1164,8 +1313,7 @@ class DeviceMapperSnapshot(object):
 
         if '--readonly' in ops or '-r' in ops or 'ro' in ops:
             self.persistent = 'P'
-        if ('tmpfs' == findmnt('-no FSTYPE -T', self.cowloop.lofile)
-            or 'N' in ops):
+        if ('tmpfs' == self.cowloop.fstype or 'N' in ops):
             self.persistent = 'N'
         if 'P' in ops:
             self.persistent = 'P'
@@ -1300,11 +1448,11 @@ class CryptoLUKSDevice(object):
                 raise CryptoLUKSError(''.join((
                       'Could not resize the crypto_LUKS device using:\n  ',
                       args)))
-            resize2fs(self.device, size=None, ops=ops)
+            resizefs(self.device, self.fstype, size=None, ops=ops)
             self.cleanup()
         else:
             self.create(ops=ops)
-            resize2fs(self.device, size, ops=ops)
+            resizefs(self.device, self.fstype, size, ops=ops)
             args += ['--size', str(size // 512)]
             if call(args) != 0:
                 raise CryptoLUKSError(''.join((
@@ -1423,7 +1571,7 @@ class LiveImageMount(object):
     """
     def __init__(self, srcdir, mountdir, rootfsimg=None, overlay=None, ops='',
                  dirmode=None):
-        self.srcdir = srcdir
+        self.srcdir = srcdir.rstrip(os.sep)
         self.liveosdir = None
         self.mountdir = mountdir
         self.mounted = False
@@ -1529,7 +1677,7 @@ class LiveImageMount(object):
                 self.cowloop.create('ro')
                 size = cow._size = os.stat(self.overlay)[stat.ST_SIZE]
                 call(['udevadm', 'settle', '-E', self.cowloop.device])
-                self.ovltype = lsblk('-ndo FSTYPE', self.cowloop.device)
+                self.ovltype = self.cowloop.fstype
                 self.cowloop.cleanup()
         else:
             if self.squashmnt is None:

--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -4,7 +4,7 @@
 # Copyright 2007-2012, Red Hat, Inc.
 # Copyright 2016-2018, Kevin Kofler
 # Copyright 2016, Neal Gompa
-# Copyright 2017-2018, Fedora Project
+# Copyright 2017-2021, Fedora Project
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -365,6 +365,11 @@ class LiveImageCreatorBase(LoopImageCreator):
                            self.__isodir + "/LiveOS/squashfs.img",
                            self.compress_args, ops)
                 self._LoopImageCreator__instloop.cleanup()
+                if self.docleanup:
+                    if os_image == self._instroot:
+                        os.remove(self._image)
+                    else:
+                        os.remove(os.path.join(os_image, 'LiveOS', 'rootfs.img'))
 
             self.__create_iso(self.__isodir)
         finally:

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -2,8 +2,8 @@
 # coding: utf-8
 #
 # Copyright 2009, Red Hat, Inc.
-# Copyright 2012-2020, Sugar Labs®
-# Forked from edit-livecd, written by Perry Myers <pmyers at redhat.com>
+# Copyright 2012-2021, Sugar Labs®
+# Superceding edit-livecd, written by Perry Myers <pmyers at redhat.com>
 #                                   & David Huff <dhuff at redhat.com>
 # Cloning code, OverlayFS, and filesystem editing added by Frederick Grose,
 #                                                     <fgrose at sugarlabs.org>
@@ -19,9 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
+
 doc1 = '''
               editliveos [options] <LiveOS_source>
 
@@ -90,9 +88,9 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [-N, --noshell]
                         [-t, --tmpdir <tmpdir>]
                         [-f, --dnfcache, -y, --yumcache <cachedir>]
-                        [-e, --exclude <exclude, s>]
-                        [-i, --include <include, s>]
-                        [-u, --seclude <seclude, s>]
+                        [-e, --exclude <exclude s>]
+                        [-i, --include <include s>]
+                        [-u, --seclude <seclude s>]
                         [-r, --releasefile <releasefile s>]
                         [-b, --builder <builder>]
                         [-p, --plugins]
@@ -109,7 +107,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [--skip-compression]
                         [--refresh-uncompressed]
                         [--flatten-squashfs]
-                        [--rootfs-size-gb [+|-]<size>]
+                        [--rootfs-size-gb [+|-]<size>[,<fstype>[,<blksz>]]]
                         [--home-size-mb [+|-]<size>[,<fstype>[,<blksz>]]]
                         [--encrypted-home]
                         [--unencrypted-home]
@@ -169,14 +167,14 @@ parser.add_argument('-f', '--dnfcache', '-y', '--yumcache', dest='cachedir',
 parser.add_argument('-e', '--exclude', dest='excludes', metavar='PATH',
     help='A string of filename patterns to exclude from the copy\nof the '
     'outer device filesystem.  See _copy_src_root().\nDenote multiple '
-    'patterns as "pattern1, pattern2, ..."\nThe default is to exclude all '
+    'patterns as "pattern1 pattern2 ..."\nThe default is to exclude all '
     'device content except for\nthe iso/syslinux, EFI, and LiveOS directories. '
     'Entering\nanything to be excluded will have the effect of\nincluding '
     'everything else but the excluded items.\n ')
 
 parser.add_argument('-i', '--include', dest='includes', metavar='PATH',
     help='A string of file or directory paths to copy to the .iso\nfile in '
-    '_copy_src_root().  Denote multiple files as\n"path1, path2, ..."  '
+    '_copy_src_root().  Denote multiple files as\n"path1 path2 ..."  '
     '(The paths are referenced\nrelative to the source mount directory, '
     'either\n/mnt/live/ or /run/initramfs/live for a running\nLiveOS, or '
     '/TMPDIR/editliveos-<random>/mp-src-<random>\nfor an attached device '
@@ -187,7 +185,7 @@ parser.add_argument('-i', '--include', dest='includes', metavar='PATH',
 parser.add_argument('-u', '--seclude', dest='secludes', metavar='PATH',
     help='A string of file or directory paths in the LiveOS\nfilesystem to '
     'seclude from the final build\nconfiguration. The user directory may '
-    'be denoted with\n~/.  Denote multiple files as "path1, path2, ..."\n'
+    'be denoted with\n~/.  Denote multiple files as "path1 path2 ..."\n'
     'By default, specific user configuration, password, &\nlog files are '
     'secluded from the packaged iso image.\nSee seclude_from_isoimage() '
     'and scrub_system() in the\ncode for the specific files.\n ')
@@ -207,7 +205,7 @@ parser.add_argument('--clone', action='store_true', default=False,
 
 parser.add_argument('--rootfsimg', metavar='PATH',
                     help='Specify a non-standard path to the base root\n'
-                         ' filesystem relative to the <LiveOS_source>.'
+                         'filesystem relative to the <LiveOS_source>.'
                          '\n ')
 
 parser.add_argument('--overlay', metavar='[DEVSPEC:]PATHSPEC',
@@ -215,12 +213,17 @@ parser.add_argument('--overlay', metavar='[DEVSPEC:]PATHSPEC',
                          '\noverlay.\n ')
 
 parser.add_argument('--rootfs-size-gb', dest='rootfs_size',
-                    metavar='[+|-]SIZE',
+                    metavar='[+|-]SIZE[,FSTYPE[,BLKSZ]]',
                     help='Specifies a new size of NN GiB for the image (or\n'
                     'changing the size by a difference of +NN or -NN GiB,\n'
-                    'if a sign is prefixed).  This is useful when\na larger '
-                    'image is needed for a script, or during\npackage updates '
-                    'in the chroot shell.\n ')
+                    'if a sign is prefixed.  If a minus -NN value is specified\n'
+                    'along with a ,FSTYPE, use an equal sign like this,\n'
+                    '--rootfs-size-gb=-NN,FSTYPE.)  This is useful when\n'
+                    'a larger image is needed for a script, or to support\n'
+                    'the installation of extra packages or updates in the\n'
+                    'chroot shell.  To change the filesystem type but not\n'
+                    'the size, enter +0,FSTYPE.  ext[234], xfs, btrfs, & f2fs\n'
+                    'are supported for FSTYPE.\n ')
 
 parser.add_argument('--home-size-mb', metavar='[+|-]SIZE[,FSTYPE[,BLKSZ]]',
                     help='Specify copying of the /home folder contents into\n'
@@ -267,9 +270,8 @@ parser.add_argument('--overlay-size-mb', metavar='[+|-]SIZE[,FSTYPE[,BLKSZ]]',
                     'Optionally, for OverlayFS overlays on vfat-formatted\n'
                     'devices, one may specify the overlay filesystem type\n'
                     'and block size by appending ,FSTYPE,BLKSZ to this\n'
-                    'argument.  Block size defaults to 4096 bytes if it is\n'
-                    'not given. ext234, xfs, & btrfs are supported for FSTYPE,'
-                    '\nalthough a btrfs OverlayFS fails to boot.\n\n'
+                    'argument.  ext[234], xfs, btrfs, & f2fs are supported for\n'
+                    'FSTYPE.  Block size defaults to 4096 bytes if not given.\n\n'
                     'To convert an OverlayFS overlay to a Device-mapper\n'
                     'snapshot overlay, use "DM_snapshot_cow" as the FSTYPE.\n'
                     'To convert a Device-mapper overlay to OverlayFS on\n'
@@ -292,8 +294,9 @@ parser.add_argument('--skip-seclude', action='store_true', default=False,
 parser.add_argument('-c', '--compress-type', metavar='ARGS',
                     help='Specify the compression type for SquashFS.\nThis '
                          'will override the current compression or lack\n'
-                         'thereof.  Multiple arguments should be specified in\n'
-                         'one string, i.e., --compress-type "type arg1 arg2 ..."\n ')
+                         'thereof.  Multiple arguments should be specified '
+                         'in\none string, i.e., --compress-type '
+                         '"type arg1 arg2 ..."\n ')
 
 parser.add_argument('--compress', action='store_true', default=None,
                     help='Specify compression for the filesystem image.\n'
@@ -353,14 +356,15 @@ parser.add_argument('-p', '--plugins', action='store_true', dest='plugins',
 
 parser.add_argument('--cacheonly', action='store_true', dest='cacheonly',
                     default=False,
-                    help='Work offline from cache, use together with --cache\n'
-                         'default = False')
+                    help='Work offline from cache, use together with '
+                         '--dnfcache.\ndefault = False')
 
 setup_logging(parser)
 
 args = parser.parse_args()
 
 print("\nSource image at '%s'" % args.liveos)
+
 
 class LiveImageEditor(LiveImageCreator):
     """
@@ -429,6 +433,10 @@ class LiveImageEditor(LiveImageCreator):
         """
 
         self._isofstype = "iso9660"
+
+        self.root_fstype = None
+
+        self.root_blksz = None
 
         self._ImageCreator__builddir = None
         """The staging directory for the build contents and mount points."""
@@ -557,11 +565,34 @@ class LiveImageEditor(LiveImageCreator):
         self.mntdir = tempfile.mkdtemp(dir='/run/media')
 
         ops = ''
+        f = ''  # variable & flag for iso-scan/filename booted host.
         if self.src_type in ('live', 'OFS'):
-            base_on = os.path.dirname(losetup('-nO BACK-FILE', '/dev/loop0'))
+            src = os.path.join('/run', 'initramfs', 'isoscandev')
+                # (^ Requires dracut verion 051 or greater.)
+            if os.path.exists(src):
+                base_on = os.path.realpath(os.readlink(src))
+                src = os.path.join('/proc', 'cmdline')
+                with open(src, 'r') as f:
+                    src = f.read()
+                f = src[src.find('iso-scan/filename=')+19:src.find(' root=')]
+                self.isosrcmnt = DiskMount(RawDisk(None, base_on),
+                              tempfile.mkdtemp(dir=self.mntdir, prefix='dev-'),
+                              dirmode=0o700)
+                self.isosrcmnt.mount()
+                base_on = os.path.join(self.isosrcmnt.mountdir, f)
+                if not os.path.exists(base_on):
+                    raise CreatorError("Failed to find '%s'." % base_on)
+                self.ovltype = 'tempdir'
+                self.skip_refresh = True
+                self.liveosmnt = self.new_liveos_mount(base_on, '/',
+                        '/run/overlayfs', self.mntdir, ops='ro', dirmode=0o700)
+                self.srcmntdir = lsblk('-no MOUNTPOINT', '/dev/loop0')
+            if not f:
+                base_on = os.path.dirname(losetup('-nO BACK-FILE', '/dev/loop0'))
+                self.srcmntdir = '/run/initramfs/live'
             fsroot = losm = '/'
-            self.srcmntdir = '/run/initramfs/live'
-            self.srcdir = base_on
+            if not f:
+                self.srcdir = base_on
             src = findmnt('-nro SOURCE,OPTIONS', '/').split()
             if src[0] == 'LiveOS_rootfs':
                 if ':' in src[1]:
@@ -572,13 +603,14 @@ class LiveImageEditor(LiveImageCreator):
                               'lowerdir=')+9:src[1].find(',upperdir=')]
                     self._overlay = src[1][src[1].find(
                                     'upperdir=')+9:src[1].find(',workdir=')]
-                    self._overlay = os.path.dirname(
-                                        os.path.realpath(self._overlay))
-                    self.overlayloop = findmnt('-no SOURCE', self._overlay)
-                    if self.overlayloop:
-                        self.srcdir = os.path.join(self.srcmntdir,
-                                      os.path.dirname(losetup('-nO BACK-FILE',
-                                      self.overlayloop)).lstrip(os.sep))
+                    if not f:
+                        self._overlay = os.path.dirname(
+                                            os.path.realpath(self._overlay))
+                        self.overlayloop = findmnt('-no SOURCE', self._overlay)
+                        if self.overlayloop:
+                            self.srcdir = os.path.join(self.srcmntdir,
+                                       os.path.dirname(losetup('-nO BACK-FILE',
+                                          self.overlayloop)).lstrip(os.sep))
                     self.imgloop = findmnt('-no SOURCE', base_mp)
             else:
                 self.liveosdir = base_on
@@ -587,9 +619,12 @@ class LiveImageEditor(LiveImageCreator):
                     self.ovltype = 'DM_snapshot_cow'
                 else:
                     self.ovltype = overlay = 'DM_linear'
-            self.liveossrc = None
-            self.bootfolder = os.path.join(self.srcdir, 'syslinux')
-            if self.ovltype != 'DM_linear':
+            if not f:
+                self.liveossrc = None
+            self.bootfolder = os.path.join(self.srcmntdir, 'syslinux')
+            if not os.path.exists(self.bootfolder):
+                self.bootfolder = os.path.join(self.srcmntdir, 'isolinux')
+            if not f and self.ovltype not in ('DM_linear', 'tempdir'):
                 self._overlay = find_overlay(base_on)
                 if self._overlay:
                     if os.path.isdir(self._overlay):
@@ -610,7 +645,8 @@ class LiveImageEditor(LiveImageCreator):
             # which would prevent refreshing with a move operation.
             base_on = findmnt('-no TARGET -T', self.tmpdir)
         if self.src_type in ('blk', 'dir'):
-            # In case the overlay is uninitialized or filesystems need recovery.
+            # Create 'rw' in case the overlay is uninitialized or filesystems
+            # need recovery.
             self.liveosmnt._LiveImageMount__create(ops='rw', dirmode=0o700)
             if isinstance(self.liveosmnt.livemount, OverlayFSMount):
                 self.src_type = 'embedded-OFS'
@@ -618,17 +654,19 @@ class LiveImageEditor(LiveImageCreator):
             if self.liveosmnt.ovltype in ('', 'temp'):
                 self._overlay = self.liveosmnt.cowloop.lofile
 
-            if self.liveosmnt.ovltype.startswith('ext'):
-                self._e2fsck_img(self.liveosmnt.overlay)
-            elif self.liveosmnt.ovltype in ('', 'temp', 'DM_snapshot_cow'):
+            if self.liveosmnt.ovltype in ('', 'temp', 'DM_snapshot_cow'):
                 try:
                     self.liveosmnt.dm_target.create('rw')
                 except MountError as e:
                     raise CreatorError("Failed to create '%s' : %s" %
                     (self.liveosmnt.dm_target.DeviceMapperTarget__name, e))
                 else:
-                    self._e2fsck_img(self.liveosmnt.dm_target.device)
+                    self._fsck_img(self.liveosmnt.dm_target.device,
+                                   self.liveosmnt.imgloop.fstype)
                     self.liveosmnt.dm_target.remove()
+            elif self.liveosmnt.ovltype != 'dir':
+                self._fsck_img(self.liveosmnt.overlay, self.liveosmnt.ovltype)
+
             if self.liveosmnt.homemnt:
                 if self.liveosmnt.EncHome:
                     if self.EncHomeReq is None:
@@ -637,7 +675,7 @@ class LiveImageEditor(LiveImageCreator):
                     tgt = self.liveosmnt.EncHome.device
                 else:
                     tgt = self.liveosmnt.homemnt.diskmount.disk.lofile
-                self._e2fsck_img(tgt)
+                self._fsck_img(tgt, self.liveosmnt.homemnt.fstype)
             ops = 'ro'
         if self.src_type not in ('live', 'OFS'):
             try:
@@ -669,33 +707,51 @@ class LiveImageEditor(LiveImageCreator):
         if self.src_type in ('OFS', 'live'):
             if not self.imgloop:
                 self.imgloop = os.path.realpath('/dev/live-base')
-            if lsblk(' -ndo FSTYPE /dev/loop0') == 'squashfs':
+            for i in ('0', '1'):
+                if lsblk(' -ndo FSTYPE /dev/loop' + i) == 'squashfs':
+                    self.is_squashed = True
+                    self.squashloop = '/dev/loop' + i
+                    break
+            if lsblk(' -ndo FSTYPE ' + self.imgloop) == 'squashfs':
                 self.is_squashed = True
-                self.squashloop = '/dev/loop0'
+                self.squashloop = self.imgloop
             if 'linear' in get_dm_table('live-rw'):
                 self._overlay = None
                 self.ovl_size = 0
-            elif not self._overlay:
+            elif not f and not self._overlay and self.liveosmnt:
                 self._overlay = self.liveosmnt.overlay.device
             if self.ovltype == 'dir':
                 self.overlaydevice = findmnt('-no SOURCE -T',
                                         '/run/initramfs/overlayfs')
             img = self.imgloop
-            self.rootfs_img = os.path.basename(
-                                        losetup('-nO BACK-FILE', self.imgloop))
-            self.liveosdir = self.srcdir
+            self.rootfs_img = os.path.basename(losetup('-nO BACK-FILE', img))
+            if f:
+                self.liveosdir = os.path.join(self.srcmntdir, 'LiveOS')
+            else:
+                self.liveosdir = self.srcdir
+            if src[0] == '/dev/mapper/live-rw':
+                self._LoopImageCreator__fstype = findmnt('-no FSTYPE', src[0])
+            else:
+                self._LoopImageCreator__fstype = findmnt('-no FSTYPE', img)
         else:
             self.liveosdir = self.liveosmnt.liveosdir
             img = losm.imgloop.device
+            self._LoopImageCreator__fstype = losm.imgloop.fstype
 
-        self._LoopImageCreator__fstype = lsblk('-ndo FSTYPE', self.imgloop)
-        self._LoopImageCreator__blocksize = os.stat(self.imgloop).st_blksize
+        self._LoopImageCreator__fslabel = lsblk('-ndo LABEL', img)
+        self._LoopImageCreator__blocksize = os.stat(img).st_blksize
+        if self.root_blksz:
+            self._LoopImageCreator__blocksize = self.root_blksz
         if self._LoopImageCreator__image_size is None:
             self._LoopImageCreator__image_size = int(get_blockdev_size(img))
             if self._LoopImageCreator__fstype == 'squashfs':
+                self._LoopImageCreator__fstype = 'ext4'
                 # Estimate root filesystem size suitable for native image.
                 self._LoopImageCreator__image_size *= 4
-                self._LoopImageCreator__fstype = 'ext4'
+        if self.root_fstype == self._LoopImageCreator__fstype:
+            self.root_fstype = None
+        if self.root_fstype:
+            self._LoopImageCreator__fstype = self.root_fstype
         if not os.path.exists(self.bootfolder):
             self.bootfolder = os.path.join(self.srcmntdir, 'syslinux')
             if not os.path.exists(self.bootfolder):
@@ -707,7 +763,9 @@ class LiveImageEditor(LiveImageCreator):
         self.isohome_img = os.path.join(self._LiveImageCreatorBase__isodir,
                                         'LiveOS', 'home.img')
 
-        if self.rootfs_size:
+        if self.rootfs_size == '+0':
+            self.rootfs_size = ''
+        elif self.rootfs_size:
             if self.rootfs_size.startswith('+') or int(self.rootfs_size) < 0:
                 self.rootfs_size = (self._LoopImageCreator__image_size +
                                         int(self.rootfs_size) * 1024 ** 3)
@@ -728,13 +786,13 @@ class LiveImageEditor(LiveImageCreator):
         if self.src_type in ('blk', 'dir') and losm.ovltype in ('', 'temp',
                                                            'DM_snapshot_cow'):
             self.liveosmnt.unmount()
-        if self.src_type == 'iso' and self.ovltype != 'dir':
+        if (self.src_type == 'iso' and self.ovltype != 'dir'
+            and not self.root_fstype):
             self.liveosmnt.cleanup()
             if self.is_squashed:
                 self.liveosmnt.squashmnt.cleanup()
             LiveImageCreator._base_on(self, base_on)
-            self._LoopImageCreator__fslabel = findmnt('-no LABEL', self._image)
-            self.fslabel = self._LoopImageCreator__fslabel
+            self.fslabel = self._LoopImageCreator__fslabel = self.name
             self._LoopImageCreator__instloop = ExtDiskMount(
                     ExistingSparseLoopbackDisk(self._image,
                                            self._LoopImageCreator__image_size),
@@ -762,7 +820,7 @@ class LiveImageEditor(LiveImageCreator):
         """
         Initialize a new mount object for the LiveOS image of an .iso,
         attached, or refreshed device.  Optionally, pass a rootfsimg or
-        overlay refernce.
+        overlay reference.
         """
         if os.path.isfile(base_on):
             self.liveossrc = DiskMount(LoopbackDisk(base_on, None, '-r'),
@@ -773,9 +831,13 @@ class LiveImageEditor(LiveImageCreator):
             self.liveossrc = None
             self.srcdir = base_on
         elif self.src_type == 'blk' and not self.liveossrc:
-            self.liveossrc = DiskMount(RawDisk(None, base_on),
-                             tempfile.mkdtemp(dir=mntdir, prefix='dev-'),
-                             dirmode=dirmode)
+            if lsblk('-nrdo TYPE', base_on) == 'part':
+                self.liveossrc = DiskMount(RawDisk(None, base_on),
+                                 tempfile.mkdtemp(dir=mntdir, prefix='dev-'),
+                                 dirmode=dirmode)
+            else:
+                raise CreatorError("%s' is not a partition.  Please check "
+                                   "your inputs.  Exiting..." % base_on)
         if self.liveossrc:
             self.liveossrc.mount(dirmode=0o400)
             self.liveossrc.rmdir = True
@@ -826,11 +888,14 @@ class LiveImageEditor(LiveImageCreator):
                     self.excludes.append(path)
 
         if findmnt('-no FSTYPE -T', fsroot) == 'overlay':
-            # Estimate because of overestimates with mounted filesystems.
-            rootfs_used = self._LoopImageCreator__image_size
+            rootfs_used = int(rcall(['df', '-B1', '--output=used', fsroot],
+                                    raise_err=False)[0].split()[-1])
+            required = self._LoopImageCreator__image_size
         else:
             rootfs_used = int(rcall(du_args, fsroot,
                                     raise_err=False)[0].split()[-2])
+            required = rootfs_used
+
         self.home_used = int(rcall(du_args, os.path.join(fsroot, 'home'),
                               raise_err=False)[0].split()[-2])
         homesize = self.home_img_size = 0
@@ -838,12 +903,8 @@ class LiveImageEditor(LiveImageCreator):
             homesize = self.home_img_size = os.stat(self.home_img).st_size
         overlaysize = None
         if self._overlay and self.src_type != 'iso':
-            if self.ovltype == 'dir':
-                overlaysize = int(rcall(['du', '-csxb'],
-                                        '/run/initramfs/overlayfs',
-                                        raise_err=False)[0].split()[-2])
-            elif self.ovltype in ('tempdir', None):
-                 overlaysize = int(rcall(['du', '-csxb'], self._overlay,
+            if self.ovltype in ('dir', 'tempdir', None):
+                 overlaysize = int(rcall(['du', '-csxb', self._overlay],
                                          raise_err=False)[0].split()[-2])
             else:
                 if os.path.isfile(self._overlay):
@@ -854,9 +915,6 @@ class LiveImageEditor(LiveImageCreator):
                     img = self._overlay
                 overlaysize = int(get_blockdev_size(img))
             self.ovl_size = overlaysize
-
-        # staged copy
-        required = rootfs_used
 
         if self.home_size_mb is not None:
             if self.home_size_mb.startswith('+') and homesize > 0:
@@ -912,16 +970,17 @@ class LiveImageEditor(LiveImageCreator):
         if self.src_type == 'iso':
             required += 64 * 1024 ** 2
 
-        available = int(disc_free_info(self.tmpdir, '-TB1')[4])
+        available = int(disc_free_info(self.tmpdir, '-TB1')[4]) # * 2
+        # Inflate available space to cover over estimated space requirements.^
+
         if os.stat(self.tmpdir).st_dev == os.stat(self.output).st_dev:
-            # needed for e2image
             required += self._LoopImageCreator__image_size
         else:
             out_available = int(disc_free_info(self.output, '-TB1')[4])
             if self._LoopImageCreator__image_size > available:
                 if self._LoopImageCreator__image_size < out_available:
                     print('''
-                    There is insufficient space on %s to resize the image.
+                    There is insufficient space on %s to build the image.
                     %s will be tried as a temporary directory.''' % (
                         self.tmpdir, self.output))
                     self.tmpdir = self.output
@@ -930,7 +989,7 @@ class LiveImageEditor(LiveImageCreator):
                     needed = (self._LoopImageCreator__image_size -
                               available) / (1024 ** 2)
                     print('''
-                    There is insufficient space on %s to resize the image.
+                    There is insufficient space on %s to build the image.
                     %d MiB of additional space is needed.''' % (self.tmpdir,
                                                                 needed))
                     if self.liveosmnt:
@@ -981,7 +1040,7 @@ class LiveImageEditor(LiveImageCreator):
                            ') bytes in the overlay.\n')).format(
                            overlaysize))
         print(''.join((' ', self.fmt,
-                     ' bytes needed to resize the filesystem.\n')).format(
+                     ' total bytes, root filesystem image size.\n')).format(
                        self._LoopImageCreator__image_size))
         print(''.join((' ' , self.fmt,
                ' bytes are estimated to be required for staging this build.\n')
@@ -1000,7 +1059,7 @@ class LiveImageEditor(LiveImageCreator):
         elif self._LoopImageCreator__image_size < rootfs_used:
             need = round((rootfs_used - self._LoopImageCreator__image_size) /
                            (1024.0 * 1024 ** 2), 2)
-            request = self.rootfs_size / (1024 ** 3)
+            request = int(self.rootfs_size or 0) / (1024 ** 3)
             print('''
             The root filesystem uses %4.2f GiB more space than the
                 %s GiB requested with --rootfs-size-gb.\n''' % (need, request))
@@ -1052,7 +1111,7 @@ class LiveImageEditor(LiveImageCreator):
                 self.newhomemnt.disk.lofile = self.newhome_img
                 print('Copying home.img')
                 shutil.copy2(self.home_img, self.newhome_img)
-                self._e2fsck_img(self.newhome_img)
+                self._fsck_img(self.newhome_img, self.newhomemnt.fstype)
             else:
                 self.liveosmnt.homemnt.cleanup()
                 if self.newhomemnt.disk.lofile != self.home_img:
@@ -1080,8 +1139,7 @@ class LiveImageEditor(LiveImageCreator):
 
         isodir = self._LiveImageCreatorBase__isodir
 
-        ignore_list = ['EFI', 'images', 'isolinux', 'syslinux',
-                       self.rootfs_img, 'squashfs.img', 'ovlwork', 'osmin.img',
+        ignore_list = [self.rootfs_img, 'squashfs.img', 'ovlwork', 'osmin.img',
                        'home.img', 'swap.img', 'overlay-*']
         if self.clone and not self.home_size_mb and self.EncHomeReq is None:
             ignore_list.remove('home.img')
@@ -1103,10 +1161,9 @@ class LiveImageEditor(LiveImageCreator):
         shutil.copytree(src, dst, symlinks=True,
                         ignore=shutil.ignore_patterns(*ignore_list))
 
-        if self.exclude_all:
-            copypaths([self.bootfolder], isodir)
+        copypaths([self.bootfolder], isodir)
 
-        for src in ('images', 'EFI', 'LICENSE', 'Fedora-Legal-README.txt'):
+        for src in ('LICENSE', 'Fedora-Legal-README.txt', 'images', 'EFI'):
             src = os.path.join(self.srcmntdir, src)
             if os.path.exists(src):
                 copypaths([src], isodir)
@@ -1131,7 +1188,7 @@ class LiveImageEditor(LiveImageCreator):
 
         if os.path.exists(self.isohome_img):
             print('Checking home.img')
-            self._e2fsck_img(self.isohome_img)
+            self._fsck_img(self.isohome_img, self.liveosmnt.homemnt.fstype)
 
 
     def id_dm_loops(self, dm_dev):
@@ -1159,7 +1216,7 @@ class LiveImageEditor(LiveImageCreator):
             if isinstance(losm.livemount, OverlayFSMount):
                 losm = losm.mountdir
 
-        if isinstance(losm, LiveImageMount):
+        if isinstance(losm, LiveImageMount) and not self.root_fstype:
             dm_dev = losm.dm_target.DeviceMapperTarget__name
             self.id_dm_loops(dm_dev)
             if self.osminloop:
@@ -1177,6 +1234,10 @@ class LiveImageEditor(LiveImageCreator):
             call(['dmsetup', 'remove', mt[4]])
 
         else:
+            if isinstance(losm, LiveImageMount):
+                if not losm.mounted:
+                    losm.mount()
+                losm = losm.mountdir
             losfs = os.path.join(losm, '.')
 
             self._LoopImageCreator__instloop = ExtDiskMount(SparseLoopbackDisk(
@@ -1193,7 +1254,7 @@ class LiveImageEditor(LiveImageCreator):
                        self._LoopImageCreator__instloop.mountdir])
             if rc != 0:
                 raise CreatorError("Failed to copy root filesystem '%s' : %s" %
-                                   (losfs,))
+                            (losfs, self._LoopImageCreator__instloop.mountdir))
             if self.liveosmnt:
                 self.liveosmnt.unmount()
 
@@ -1299,7 +1360,7 @@ class LiveImageEditor(LiveImageCreator):
                     LoopbackDisk.create(self.newhomemnt.disk)
                     p = self.newhomemnt.disk.lofile
                 print('Checking new home.img')
-                self._e2fsck_img(p)
+                self._fsck_img(p, self.newhomemnt.fstype)
         else:
             if self.clone and os.path.exists(self.isohome_img):
                 self.newhomemnt = DiskMount(ExistingSparseLoopbackDisk(
@@ -1333,7 +1394,7 @@ class LiveImageEditor(LiveImageCreator):
             urandom = os.path.join(self._instroot, 'dev', 'urandom')
             if not os.path.exists(urandom):
                 origumask = os.umask(0000)
-                os.mknod(urandom, 0o666 | stat.S_IFCHR, os.makedev(1,9))
+                os.mknod(urandom, 0o666 | stat.S_IFCHR, os.makedev(1, 9))
                 os.umask(origumask)
 
             bindmounts = [('/sys', None), ('/proc', None), ('/dev/pts', None),
@@ -1350,7 +1411,7 @@ class LiveImageEditor(LiveImageCreator):
                     self._ImageCreator__bindmounts.extend(
                         [BindChrootMount(f, self._instroot, dest)])
                 else:
-                    logging.warn("Skipping (%s, %s) because source doesn't "
+                    logging.warning("Skipping (%s, %s) because source doesn't "
                                  "exist." % (f, dest))
             self._do_bindmounts()
             if self.force_selinux:
@@ -1361,6 +1422,32 @@ class LiveImageEditor(LiveImageCreator):
         if not os.path.islink(mtab):
             os.remove(mtab)
             os.symlink('/proc/self/mounts', mtab)
+
+
+    def check_kernel_versions(self, isodir):
+        """
+        Check that the kernel version in the root filesystem matches that
+        called by the boot loader.
+        """
+        kernel = os.path.join(isodir, 'isolinux', 'vmlinuz')
+        if not os.path.exists(kernel):
+            kernel = os.path.join(isodir, 'isolinux', 'vmlinuz0')
+        self.kernel_release = get_file_info(kernel)[7]
+        kernels = os.listdir(os.path.join(self._instroot, 'usr', 'lib',
+                                          'modules'))
+        if self.kernel_release not in kernels:
+            s = input('''\nTAKE NOTE:  The boot loader invokes kernel version
+            '%s'.\n
+            This version is not among those installed in the root filesystem:
+            \r%s\n
+            The kernel may have been upgraded or reside in an overlay.
+            If the boot kernel version is not available in the root filesystem,
+            the booted operating system will most likely fail.\n
+            Enter 'a' to abort or just press Enter to continue...
+            ''' % (self.kernel_release, '\n'.join(kernels)))
+            if s == 'a':
+                raise CreatorError('''Aborting edit due to mismatching kernels.
+                Exiting...''')
 
 
     def _brand(self, isodir):
@@ -1384,10 +1471,7 @@ class LiveImageEditor(LiveImageCreator):
         if f > -1:
             release = release[f+6:]
 
-        kernel = os.path.join(isodir, 'isolinux', 'vmlinuz')
-        if not os.path.exists(kernel):
-            kernel = os.path.join(isodir, 'isolinux', 'vmlinuz0')
-        self.kernel_release = get_file_info(kernel)[7].rsplit('.', 2)
+        self.kernel_release = self.kernel_release.rsplit('.', 2)
         arch = self.kernel_release[-1]
 
         if self.name.startswith(':'):
@@ -1435,7 +1519,10 @@ class LiveImageEditor(LiveImageCreator):
         """Restore the boot configuration files for an iso image boot."""
 
         isocfgf = os.path.join(isodir, 'isolinux', 'isolinux.cfg')
-        os.rename(self.cfgf, isocfgf)
+        if os.path.exists(isocfgf):
+            self.cfgf = isocfgf
+        else:
+            os.rename(self.cfgf, isocfgf)
 
         cmd = ['sed', '-i', '-r']
 
@@ -1496,8 +1583,9 @@ s/\<(root=live:[^ ]*)\s+[^\n.]*\<(rd\.live\.image|liveimg)/\1 \2/
             iso_boot = os.path.join('images', 'pxeboot')
             if not os.path.exists(os.path.join(isodir, iso_boot)):
                 iso_boot = 'isolinux'
-            sedscript = r'''s/^\s*set\s+timeout=.*/set timeout=60/
-s/(--set=root -l ').+'/\1{0}'/
+            sedscript = r'''/^\s*insmod\s+(fat|xfs|f2fs|btrfs)\s*$/ s/(fat|xfs|f2fs|btrfs)/ext2/
+s/(--set=root ).+'/\1-l '{0}'/
+s/^\s*set\s+timeout=.*/set timeout=60/
 /^\s*menuentry\s+'(Start|Install)\s+/,/\s*\}}/ {{s/\s+'(Start|Install)\s+.+'/ 'Start {1}'/
 s/(rd\.live\.image|liveimg).*/\1 quiet/}}
 /^\s*menuentry\s+'Test\s+/,/\s*}}/ {{s/\s+&\s+(start|install)\s+.+'/ \& start {1}'/
@@ -1517,7 +1605,7 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
             sedscript = r's/(rd\.live\.image|liveimg)/\1 %s /' % self.kernelargs
         if self.ks:
             # bootloader --append "!opt-to-remove opt-to-add"
-            for param in kickstart.get_kernel_args(self.ks,"").split():
+            for param in kickstart.get_kernel_args(self.ks, "").split():
                 if param.startswith('!'):
                     param=param[1:]
                     # remove parameter prefixed with !
@@ -1693,7 +1781,7 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
 
                 [zero_file(os.path.join(instroot, p)) for p in se2]
 
-        if not (self.clone or self.src_type == 'iso'):
+        if not (self.clone or self.skip_seclude or self.src_type == 'iso'):
             self.scrub_system(instroot)
 
 
@@ -1746,8 +1834,6 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
         if self.skip_refresh:
             [os.remove(f) for f in self.seclude_tar]
             self.seclude_tar = []
-        if self.liveosmnt:
-            self.liveosmnt.cleanup()
 
 
     def _space_for_refresh(self, isodir, isoliveosdir):
@@ -2052,14 +2138,14 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
             self.liveossrc.cleanup()
 
 
-    def _e2fsck_img(self, img):
+    def _fsck_img(self, img, fstype):
         """Check and report on a filesystem."""
 
         print('  Checking filesystem: %s' % img)
-        if e2fsck(img) != 0:
-            print('Attempt 1: e2fsck of %s detected some errors.' % img)
-            if e2fsck(img) != 0:
-                raise CreatorError('e2fsck of %s failed!' % img)
+        if fsck(img, fstype) != 0:
+            print('Attempt 1: fsck of %s detected some errors.' % img)
+            if fsck(img, fstype) != 0:
+                raise CreatorError('fsck of %s failed!' % img)
             else:
                 print('Attempt 2: passed.')
 
@@ -2161,6 +2247,8 @@ def main():
                 raise CreatorError('\nNotice: home-blksz: %s is not a valid '
                 'number.\n     Please correct this.\nError: %s' % (
                     homefs[2], e))
+            else:
+                checkfsblksz(homefs[1], int(homefs[2]), 'home', int(homefs[0]))
     if args.overlay_size_mb:
         ovlfs = args.overlay_size_mb.split(',')
         try:
@@ -2176,13 +2264,26 @@ def main():
                 raise CreatorError('\nNotice: ovl-blksz: %s is not a valid '
                 'number.\n     Please correct this.\nError: %s' % (
                     ovlfs[2], e))
+            else:
+                checkfsblksz(ovlfs[1], int(ovlfs[2]), 'ovl', int(ovlfs[0]))
     if args.rootfs_size:
+        rootfs = args.rootfs_size.split(',')
         try:
-            int(args.rootfs_size)
+            int(rootfs[0])
         except ValueError as e:
             raise CreatorError('\nNotice: --rootfs-size-gb: %s is not a '
             'valid number.\n     Please correct this.\nError: %s' % (
-                args.rootfs_size, e))
+                rootfs[0], e))
+        if len(rootfs) > 2:
+            try:
+                int(rootfs[2])
+            except ValueError as e:
+                raise CreatorError('\nNotice: rootfs-blksz: %s is not a valid '
+                'number.\n     Please correct this.\nError: %s' % (
+                    rootfs[2], e))
+            else:
+                checkfsblksz(rootfs[1], int(rootfs[2]), 'dev', int(rootfs[0]))
+
     name = ''.join((os.path.basename(args.liveos.rstrip('/')), '.edited'))
     src_type = 'iso'
     if args.liveos == 'live' or args.liveos in (
@@ -2238,13 +2339,13 @@ def main():
     editor.src_type = src_type
     editor.exclude_all = False
     if args.excludes:
-        editor.excludes = args.excludes.split(', ')
+        editor.excludes = args.excludes.split()
     else:
         editor.exclude_all = True
     if args.includes:
-        editor.includes = args.includes.split(', ')
+        editor.includes = args.includes.split()
     if args.secludes:
-        editor.secludes = args.secludes.split(', ')
+        editor.secludes = args.secludes.split()
     editor.dmsetup_cmd = ['dmsetup']
     if '--noudevsync' in rcall(['dmsetup', '-h'])[1]:
         editor.dmsetup_cmd = ['dmsetup', '--noudevrules', '--noudevsync']
@@ -2253,6 +2354,16 @@ def main():
     editor.shell = args.shell
     editor.clone = args.clone
     editor.rootfs_size = args.rootfs_size
+    if args.rootfs_size:
+        editor.rootfs_size = rootfs[0]
+        try:
+            editor.root_fstype = rootfs[1]
+        except IndexError:
+            editor.root_fstype = 'ext4'
+        try:
+            editor.root_blksz = rootfs[2]
+        except IndexError:
+            editor.root_blksz = 4096
     editor.home_size_mb = args.home_size_mb
     if args.home_size_mb:
         editor.home_size_mb = homefs[0]
@@ -2324,6 +2435,7 @@ def main():
                                                    editor.ks)
         editor._pre_mount(args.liveos, args.rootfsimg, args.overlay)
         editor.mount(editor.cachedir)
+        editor.check_kernel_versions(editor._LiveImageCreatorBase__isodir)
         if not editor.refresh_only:
             editor._brand(editor._LiveImageCreatorBase__isodir)
             editor._configure_bootloader(editor._LiveImageCreatorBase__isodir)
@@ -2370,6 +2482,9 @@ def main():
                     Please wait...''')
         if not editor.refresh_only and not editor.skip_seclude:
             editor.seclude_from_isoimage()
+        if editor.liveosmnt:
+            editor.liveosmnt.cleanup()
+
         editor.unmount()
 
         if editor.src_type == 'iso':
@@ -2411,7 +2526,10 @@ def main():
                      during the LiveOS and overlay refresh.
                   ''')
         if editor.src_type == 'blk' and os.path.ismount(editor.srcmntdir):
-            os.system('umount ' + editor.srcmntdir)
+            os.system('umount --detach-loop ' + editor.srcmntdir)
+        if hasattr(editor, 'isosrcmnt'):
+            editor.isosrcmnt.unmount()
+            editor.liveossrc.cleanup()
         if success and editor.docleanup and editor.src_type != 'iso':
             shutil.rmtree(editor.mntdir)
 

--- a/tools/liveimage-mount
+++ b/tools/liveimage-mount
@@ -6,7 +6,7 @@
 #
 # Copyright 2011, Red Hat, Inc.
 # Copyright 2016, Neal Gompa
-# Copyright 2017-2019, Sugar Labs®
+# Copyright 2017-2021, Sugar Labs®
 #   Code for Live mounting an attached LiveOS device added by Frederick Grose,
 #   <fgrose at sugarlabs.org>
 #   Ported to Python 3 by Neal Gompa <ngompa13 at gmail.com>
@@ -24,7 +24,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-from __future__ import print_function
 import os
 import sys
 import stat
@@ -209,7 +208,7 @@ def mount(userargs, ops=None):
 def loop_setup(path, ops=None):
     """Make and associate a loop device with an image file or device."""
 
-    args = ['losetup', '--direct-io', '-P', '-f', '--show', path]
+    args = ['losetup', '-P', '-f', '--show', path]
     if ops:
         args += ops.split()
     return rcall(args)[0].rstrip()
@@ -419,13 +418,14 @@ def main():
                 loop_detach(homedev)
         if os.path.exists(os.path.join('/dev', 'mapper', 'EncHome' + X)):
             cryptsetup('close EncHome')
-        if os.path.exists(os.path.join('/dev', 'mapper', 'live-rw' + X)):
-            dmsetup('remove --retry live-rw' + X)
-        loop_detach(tmpoverlayloop)
-        if os.path.exists(os.path.join('/dev', 'mapper', 'live-ro' + X)):
-            dmsetup('remove --retry live-ro' + X)
-        loop_detach(overlayloop)
-        loop_detach(imgloop)
+        if not overlayfs:
+            if os.path.exists(os.path.join('/dev', 'mapper', 'live-rw' + X)):
+                dmsetup('remove --deferred --retry live-rw' + X)
+            loop_detach(tmpoverlayloop)
+            if os.path.exists(os.path.join('/dev', 'mapper', 'live-ro' + X)):
+                dmsetup('remove --deferred --retry live-ro' + X)
+            loop_detach(overlayloop)
+            loop_detach(imgloop)
         if os.path.ismount(squashmnt):
             call(['umount', '-d', squashmnt])
         if unmount == 'yes':
@@ -778,10 +778,12 @@ def main():
         if mount_hacks:
             subprocess.check_call(['mount', '-t', 'proc', 'proc',
                              os.path.join(destmnt, 'proc')], stderr=sys.stderr)
-            subprocess.check_call(['mount', '-t', 'tmpfs', 'tmpfs',
+            subprocess.check_call(['mount', '--bind', '/run',
                        os.path.join(destmnt, 'run')], stderr=sys.stderr)
-            subprocess.check_call(['mount', '-t', 'sysfs', 'sys',
+            subprocess.check_call(['mount', '--bind', '/sys',
                 os.path.join(destmnt, 'sys')], stderr=sys.stderr)
+            subprocess.check_call(['mount', '--bind', '/dev',
+                       os.path.join(destmnt, 'dev')], stderr=sys.stderr)
             tmpfs = os.path.join(destmnt, 'dev', 'pts')
             if not os.path.exists(tmpfs):
                 os.makedirs(tmpfs)


### PR DESCRIPTION
A cumulative update, best reviewed by testing.
```
Enable formatting of a separate EFI System Partition and Apple HFS+ boot
  partition based on the files efiboot.img and macboot.img in the /images
  directory of the source.  This means EFI booting is possible with overlay
  sizes as large as the free space on the primary partition.
Support F2FS type formatting for the device root, home, or overlay
  filesystems.
Provide a GRUB EFI boot binary with basic F2FS filesystem support for
  x86_64 architecture systems.
Provide boot support for F2FS extra_attr formatted discs with an EFI Boot
  Stub loader from dracut, as GRUB support for this format is faulty at
  this time.
Allow conversion of the root filesystem type between ext[234], btrfs, xfs,
  & F2FS and their available block sizes with editliveos.
Allow a Device-mapper target to be the target device for installation.
  This would enable concurrent multi device installation through a
  preconfigured Device-mapper mirror target.

Also,
  - introduce the --noesp option to --format to avoid the extra partitions;
  - on UEFI booted hosts, for F2FS extra_attr formatted installations,
    offer to create a UEFI boot entry;
  - do not require SYSLINUX-EXTLINUX on the installation host;
  - take greater advantage of BASH case statements for code structure;
  - use fallocate on filesystem creation to reserve storage space for
    embedded filesystems;
  - add a trap ERR line for error reporting in livecd-iso-to-disk;
  - provide better support for isoscan/filename boots from .iso files;
  - delete the uncompressed image file just after compression to make
    more space available, if preservation of temporary files is not selected;
  - use bind mounts for /run, /sys, & /dev and the --deferred option on
    dmsetup remove in liveimage-mount;
  - update documentation.
```