### PR TITLE
Add missing files to uninstall section of makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,15 @@ install: man
 uninstall:
 	rm -f $(DESTDIR)/usr/bin/livecd-creator
 	rm -rf $(DESTDIR)/usr/lib/livecd-creator
-	rm -rf $(DESTDIR)/usr/share/doc/livecd-tools-$(VERSION)
+	rm -rf $(DESTDIR)/usr/share/doc/livecd-tools
 	rm -f $(DESTDIR)/usr/bin/mkbiarch
+	rm -f $(DESTDIR)/usr/bin/liveimage-mount
+	rm -f $(DESTDIR)/usr/bin/livecd-iso-to-disk
+	rm -f $(DESTDIR)/usr/bin/livecd-iso-to-pxeboot
+	rm -f $(DESTDIR)/usr/bin/editliveos
+	rm -rf $(DESTDIR)/$(PYTHONDIR)/imgcreate
+	rm -f $(DESTDIR)/usr/share/man/man8/livecd-creator.8
+	rm -f $(DESTDIR)/usr/share/man/man8/livecd-iso-to-disk.8
 
 dist : all
 	git archive --format=tar --prefix=livecd-tools-$(VERSION)/ HEAD | gzip -9v > livecd-tools-$(VERSION).tar.gz


### PR DESCRIPTION
After testing the master branch version of livecd-tools I attempted to uninstall it. However I found that many files that were installed via "make install" were still present after "make uninstall". I updated the uninstall section as follows:

1. Added lines to uninstall additional scripts installed in /usr/bin.
2. Added lines to remove man pages.
3. Fixed path to remove files under /usr/share/doc; the uninstall section tried to remove a versioned path but the install used an unversioned path.