### PR TITLE
imgcreate/live: Add missing variable "_isDracut"

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -82,6 +82,7 @@ class LiveImageCreatorBase(LoopImageCreator):
                           "virtio_balloon", "virtio-rng"]
 
         self._isofstype = "iso9660"
+        self._isDracut = True
         self.base_on = False
 
         self.title = title


### PR DESCRIPTION
This should fix issues where it's being referenced directly.
We generally expect Dracut to be used, so the value is set to true
by default.

Fixes #172