### PR TITLE
prevent urlgrabber.urlgrab() from overwriting kickstart-file

### DIFF
--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -51,8 +51,10 @@ def read_kickstart(path):
     version = ksversion.makeVersion()
     ks = ksparser.KickstartParser(version)
     try:
-        ksfile = urlgrabber.urlgrab(path)
-        ks.readKickstart(ksfile)
+        tmpks = '.kstmp.{}'.format(os.getpid())
+        ksfile = urlgrabber.urlgrab(path, filename=tmpks)
+        ks.readKickstart(tmpks)
+        os.unlink (tmpks)
 # Fallback to e.args[0] is a workaround for bugs in urlgragger and pykickstart.
     except IOError as e:
         raise errors.KickstartError("Failed to read kickstart file "


### PR DESCRIPTION
When kickstart-file (--config parameter to livecd-creator) is located in current directory, urlgrabber.urlgrab() (without filename= paramater) will try to download the file using the basename of the path argument, resulting in overwriting the kickstart file. The result is a kickstart file of 0 bytes.

This patch adds a filename parameter to a hidden file in the current directory to avoid overwriting the original kickstart file. After being parsed, the temporary file is deleted.