### PR TITLE
Fix check if EFI bootloader exists

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -232,8 +232,8 @@ class LiveImageCreatorBase(LoopImageCreator):
 
     def _generate_efiboot(self, isodir):
         """Generate EFI boot images."""
-        if not glob.glob(self._instroot+"/boot/efi/EFI/*/shim*.efi"):
-            logging.error("Missing shim.efi, skipping efiboot.img creation.")
+        if not glob.glob(isodir + "/EFI/BOOT/BOOT*.EFI"):
+            logging.error("Missing initial EFI bootloader, skipping efiboot.img creation.")
             return
 
         # XXX-BCL: does this need --label?


### PR DESCRIPTION
A path of initial location before copying files to the isodir was checked.
Let's better check the real location which will be fed to mkefiboot bellow.