### PR TITLE
mkdir isolinux on aarch64

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -1187,6 +1187,7 @@ submenu 'Troubleshooting -->' {
 
     def _configure_efi_bootloader(self, isodir):
         """Set up the configuration for an EFI bootloader"""
+        makedirs(isodir + "/isolinux")
         if self.__copy_efi_files(isodir):
             shutil.rmtree(isodir + "/EFI")
             logging.warning("Failed to copy EFI files, no EFI Support will be included.")


### PR DESCRIPTION
It was made on x86 (just because ISOs are made for both EFI and non-EFI) but was not in aarch64
This duplication of code looks ugly but I don't know how to make it better