### PR TITLE
Modernize detection of checkisomd5

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -134,12 +134,7 @@ class LiveImageCreatorBase(LoopImageCreator):
     #
     def _has_checkisomd5(self):
         """Check whether checkisomd5 is available in the install root."""
-        for c in '/usr/lib/anaconda-runtime/checkisomd5', 'checkisomd5':
-            if chrootentitycheck(c, self._instroot):
-                return True
-                break
-        else:
-            return False
+        return chrootentitycheck('checkisomd5', self._instroot)
 
     #
     # Actual implementation


### PR DESCRIPTION
I do not know what /usr/lib/anaconda-runtime/checkisomd5 is and when it existed,
it does not exist in modern Anaconda

chrootentitycheck() prints error message when it tries to find not existing binary
and then does not print anything when the second variant is found. It is confusing.