### PR TITLE
make live image the default boot option

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -728,7 +728,7 @@ menu end
 
     def __get_basic_efi_config(self, **args):
         return """
-set default="1"
+set default="0"
 
 function load_video {
   insmod efi_gop
@@ -1111,7 +1111,7 @@ class aarch64LiveImageCreator(LiveImageCreatorBase):
 
     def __get_basic_efi_config(self, **args):
         return """
-set default="1"
+set default="0"
 
 function load_video {
   insmod efi_gop


### PR DESCRIPTION
When using bios, the live image is the default option in the boot menu. However when using efi, the default is the second entry ("Troubleshooting"). This PR changes the default under efi so that bios and efi behaves the same and the live image is the default for both.