### PR TITLE
switch from authconfig to authselect

### DIFF
--- a/config/livecd-fedora-minimal.ks
+++ b/config/livecd-fedora-minimal.ks
@@ -1,7 +1,7 @@
 lang en_US.UTF-8
 keyboard us
 timezone US/Eastern
-auth --useshadow --passalgo=sha512
+authselect select sssd with-silent-lastlog --force
 selinux --enforcing
 firewall --disabled
 part / --size 2048

--- a/config/livecd-mageia-minimal-i586.ks
+++ b/config/livecd-mageia-minimal-i586.ks
@@ -1,7 +1,7 @@
 lang en_US.UTF-8
 keyboard us
 timezone US/Eastern
-auth --useshadow --passalgo=sha512
+authselect select sssd with-silent-lastlog --force
 selinux --disabled
 firewall --disabled
 part / --size 1536

--- a/config/livecd-mageia-minimal-x86_64.ks
+++ b/config/livecd-mageia-minimal-x86_64.ks
@@ -1,7 +1,7 @@
 lang en_US.UTF-8
 keyboard us
 timezone US/Eastern
-auth --useshadow --passalgo=sha512
+authselect select sssd with-silent-lastlog --force
 selinux --disabled
 firewall --disabled
 part / --size 1536

--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -788,7 +788,7 @@ class ImageCreator(object):
         kickstart.LanguageConfig(self._instroot).apply(ksh.lang)
         kickstart.KeyboardConfig(self._instroot).apply(ksh.keyboard)
         kickstart.TimezoneConfig(self._instroot).apply(ksh.timezone)
-        kickstart.AuthConfig(self._instroot).apply(ksh.authconfig)
+        kickstart.AuthSelect(self._instroot).apply(ksh.authselect)
         kickstart.FirewallConfig(self._instroot).apply(ksh.firewall)
         kickstart.RootPasswordConfig(self._instroot).apply(ksh.rootpw)
         kickstart.ServicesConfig(self._instroot).apply(ksh.services)

--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -179,17 +179,16 @@ class TimezoneConfig(KickstartConfig):
                 os.unlink(localtime)
             os.symlink("/usr/share/zoneinfo/%s" %(tz,), localtime)
 
-class AuthConfig(KickstartConfig):
-    """A class to apply a kickstart authconfig configuration to a system."""
-    def apply(self, ksauthconfig):
+class AuthSelect(KickstartConfig):
+    """A class to apply a kickstart authselect configuration to a system."""
+    def apply(self, ksauthselect):
 
-        auth = ksauthconfig.authconfig or "--useshadow --enablemd5"
-        args = ["authconfig", "--update", "--nostart"]
+        auth = ksauthselect.authselect or "select sssd with-silent-lastlog --force"
         try:
-            subprocess.call(args + auth.split(), preexec_fn=self.chroot)
+            subprocess.call(['authselect'] + auth.split(), preexec_fn=self.chroot)
         except OSError as e:
             if e.errno == errno.ENOENT:
-                logging.info('The authconfig command is not available.')
+                logging.info('The authselect command is not available.')
                 return
 
 class FirewallConfig(KickstartConfig):


### PR DESCRIPTION
Authconfig compatibility tool (from authselect-compat) will be removed from Fedora 35:
https://fedoraproject.org/wiki/Changes/RemoveAuthselectCompatPackage

---

Mageia does not seem to have authselect. Are those kickstarts used by the tool
any way?