### PR TITLE
livecd-iso-to-disk & editliveos: Preserve extra-kernel-args from source.  Refresh vmlinuz & initrd.img upon kernel updates.

### DIFF
--- a/README
+++ b/README
@@ -162,7 +162,7 @@ livecd-iso-to-disk script, like the following:
    livecd-iso-to-disk /path/to/live.iso /dev/sdb1
 
 Replace the '/dev/sdb1' argument above with the (unmounted) partition where you
-wish to load the live image.  This is not a destructive process; any data you 
+wish to load the live image.  This is not a destructive process; any data you
 currently have on your USB stick will be preserved.
 
 Multiple images may be loaded onto a single USB stick.
@@ -185,10 +185,11 @@ Live OS images may be edited using the editliveos script:
 
    editliveos [options] <LiveOS_source>
 
-This script may be used to merge a persistent overlay, insert files, clone a
+This script may be used to merge a persistent overlay, run software updates
+including kernel and initial RAM filesystem updates, insert files, clone a
 customized instance, adjust the root or home filesystem or overlay sizes and
 filesystem or overlay types, seclude private or user-specific files, rebuild
-the image into a new, .iso image distribution file, and refresh the source's
+the image into a new .iso image distribution file, and refresh the source's
 persistent filesystem overlay.
 
 See editliveos --help for more options and instructions.

--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -86,15 +86,15 @@ This option is necessary for most Intel Macs.
 
 When --efi is used without --format but with --reset-mbr, it loads a hybrid (EFI)/MBR bootloader on the device.
 
-=item --noesp    (Used with --format.)
+=item --noesp    (Used with --format)
 
-Skip the formatting of an EFI System Partition and Mac boot partition.
+Skips the formatting of a secondary EFI System Partition and an Apple HFS+ boot partition.
 
 Note: Even with this option, EFI components are configured and loaded on the primary partition if they are present on the source.
 
 =item --reset-mbr|--resetmbr
 
-Sets the Master Boot Record (MBR) of the target storage device to the F<mbr.bin> or F<gptmbr.bin> file from the installation system's F<syslinux> directory.  This may be helpful in recovering a damaged or corrupted device.
+Sets the Master Boot Record (MBR) of the target storage device to the F<mbr.bin> or F<gptmbr.bin> file from the installation system's F<syslinux> directory.  This may be helpful in recovering a damaged or corrupted device.  Also sets the legacy_boot flag on the primary partition for GPT disks.
 
 =item --multi
 

--- a/imgcreate/util.py
+++ b/imgcreate/util.py
@@ -2,7 +2,7 @@
 # util.py : Various utility methods
 #
 # Copyright 2010, Red Hat, Inc.
-# Copyright 2017, Fedora Project
+# Copyright 2017-2021, Fedora Project
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 import subprocess
 import logging
 import io
+from errors import *
 
 def call(*popenargs, **kwargs):
     """

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -23,11 +23,13 @@
 doc1 = '''
               editliveos [options] <LiveOS_source>
 
-              Edit a LiveOS image to merge a persistent overlay, insert files,
-              clone a customized instance, adjust the root or home filesystem
-              or overlay sizes, seclude private or user-specific files, rebuild
-              the image into a new, .iso image distribution file, and refresh
-              the source's persistent filesystem overlay.'''
+              Edit a LiveOS image to merge a persistent overlay, run software
+              updates including kernel and initial RAM filesystem updates,
+              insert files, clone a customized instance, adjust the root or
+              home filesystem or overlay sizes, seclude private or user-
+              specific files, rebuild the image into a new .iso image
+              distribution file, and refresh the source's persistent filesystem
+              overlay.'''
 doc2 = '''
  USAGE HELP   editliveos -h, -?, --help
 
@@ -479,6 +481,9 @@ class LiveImageEditor(LiveImageCreator):
         self.liveosmnt = None
         """Mount object for the source LiveOS image."""
 
+        self.srcmntdir = None
+        """Mount point for the source LiveOS image partition."""
+
         self.newhomemnt = None
         """Mount object for a cloned home.img filesystem."""
 
@@ -626,9 +631,6 @@ class LiveImageEditor(LiveImageCreator):
                     self.ovltype = overlay = 'DM_linear'
             if not f:
                 self.liveossrc = None
-            self.bootfolder = os.path.join(self.srcmntdir, 'syslinux')
-            if not os.path.exists(self.bootfolder):
-                self.bootfolder = os.path.join(self.srcmntdir, 'isolinux')
             if not f and self.ovltype not in ('DM_linear', 'tempdir'):
                 self._overlay = find_overlay(base_on)
                 if self._overlay:
@@ -707,7 +709,6 @@ class LiveImageEditor(LiveImageCreator):
             self.ovltype = self.liveosmnt.ovltype
             self.srcmntdir = findmnt('-no TARGET -T', losm.srcdir)
             self.imgloop = losm.imgloop.device
-            self.bootfolder = os.path.join(losm.srcdir, 'syslinux')
 
         if self.src_type in ('OFS', 'live'):
             if not self.imgloop:
@@ -757,12 +758,11 @@ class LiveImageEditor(LiveImageCreator):
             self.root_fstype = None
         if self.root_fstype:
             self._LoopImageCreator__fstype = self.root_fstype
-        if not os.path.exists(self.bootfolder):
-            self.bootfolder = os.path.join(self.srcmntdir, 'syslinux')
-            if not os.path.exists(self.bootfolder):
-                self.bootfolder = os.path.join(self.srcmntdir, 'isolinux')
         if not os.path.exists(self.liveosdir):
             raise CreatorError("No LiveOS directory on %s" % base_on)
+        self.bootfolder = os.path.join(self.liveosmnt.srcdir, 'syslinux')
+        if not os.path.exists(self.bootfolder):
+            self.bootfolder = os.path.join(self.srcmntdir, 'isolinux')
 
         self.home_img = os.path.join(self.liveosdir, 'home.img')
         self.isohome_img = os.path.join(self._LiveImageCreatorBase__isodir,
@@ -953,8 +953,8 @@ class LiveImageEditor(LiveImageCreator):
             else:
                 self.overlay_size_mb = int(
                                         self.overlay_size_mb) * 1024 ** 2
-            if self._overlay and os.stat(self._overlay).st_dev == os.stat(
-                                                           self.output).st_dev:
+            if not self.refresh_only and self._overlay and os.stat(
+                self._overlay).st_dev == os.stat(self.output).st_dev:
                 # if overlay is on staging device
                 if self.overlay_size_mb > 0:
                     required += self.overlay_size_mb - self.ovl_size
@@ -978,7 +978,8 @@ class LiveImageEditor(LiveImageCreator):
         available = int(disc_free_info(self.tmpdir, '-TB1')[4]) # * 2
         # Inflate available space to cover over estimated space requirements.^
 
-        if os.stat(self.tmpdir).st_dev == os.stat(self.output).st_dev:
+        if not self.refresh_only and os.stat(self.tmpdir).st_dev == os.stat(
+                                                           self.output).st_dev:
             required += self._LoopImageCreator__image_size
         else:
             out_available = int(disc_free_info(self.output, '-TB1')[4])
@@ -1145,7 +1146,7 @@ class LiveImageEditor(LiveImageCreator):
         isodir = self._LiveImageCreatorBase__isodir
 
         ignore_list = [self.rootfs_img, 'squashfs.img', 'ovlwork', 'osmin.img',
-                       'home.img', 'swap.img', 'overlay-*']
+         'home.img', 'swap.img', 'overlay-*', 'images', 'syslinux', 'isolinux']
         if self.clone and not self.home_size_mb and self.EncHomeReq is None:
             ignore_list.remove('home.img')
 
@@ -1166,9 +1167,10 @@ class LiveImageEditor(LiveImageCreator):
         shutil.copytree(src, dst, symlinks=True,
                         ignore=shutil.ignore_patterns(*ignore_list))
 
-        copypaths([self.bootfolder], isodir)
+        for src in (self.bootfolder, os.path.join(self.srcdir, 'images')):
+            copypaths([src], isodir)
 
-        for src in ('LICENSE', 'Fedora-Legal-README.txt', 'images', 'EFI'):
+        for src in ('LICENSE', 'Fedora-Legal-README.txt', 'EFI'):
             src = os.path.join(self.srcmntdir, src)
             if os.path.exists(src):
                 copypaths([src], isodir)
@@ -1430,30 +1432,95 @@ class LiveImageEditor(LiveImageCreator):
             os.symlink('/proc/self/mounts', mtab)
 
 
-    def check_kernel_versions(self, isodir):
+    def check_kernel_versions(self, isodir, msg):
         """
         Check that the kernel version in the root filesystem matches that
         called by the boot loader.
         """
-        kernel = os.path.join(isodir, 'vmlinuz')
-        if not os.path.exists(kernel):
-            kernel = os.path.join(isodir, 'vmlinuz0')
-        self.kernel_release = get_file_info(kernel)[7]
-        kernels = os.listdir(os.path.join(self._instroot, 'usr', 'lib',
-                                          'modules'))
-        if self.kernel_release not in kernels:
-            s = input('''\nTAKE NOTE:  The boot loader invokes kernel version
-            '%s'.\n
-            This version is not among those installed in the root filesystem:
-            \r%s\n
+        self.kernel = os.path.join(isodir, 'vmlinuz')
+        if not os.path.exists(self.kernel):
+            self.kernel = os.path.join(isodir, 'vmlinuz0')
+        vm = os.path.basename(self.kernel)
+        self.kernel_release = get_file_info(self.kernel)[7]
+        if not self.kernels:
+            self.kernels = glob.glob(os.path.join(self._instroot, 'usr',
+                                             'lib', 'modules', '*', 'vmlinuz'))
+            self.kernels = [os.path.basename(e) for e in [os.path.dirname(e)
+                                                        for e in self.kernels]]
+        self.initrd = os.path.join(isodir, 'initrd.img')
+        if not os.path.exists(self.initrd):
+            self.initrd = os.path.join(isodir, 'initrd0.img')
+        img = os.path.basename(self.initrd)
+        if msg == 'update' and self.kernels != self.kernels0:
+            print('Updating kernel & initial ram filesystem images...')
+            cmd = ['sort', '-rV']
+            a, err, rc = rcall(cmd, '\n'.join(self.kernels))
+            a = a.split('\n')[0]
+            rc = os.path.join(self._instroot, 'boot',
+                                               'initramfs-' + a + '.img')
+            d = os.path.join(self._instroot, 'usr', 'lib', 'modules', a)
+            cmd = ['dracut', rc, '--kmoddir', d, '--kver', a, '--no-hostonly',
+                   '--add', 'dmsquash-live', '--force']
+            if self.src_fstype == 'f2fs':
+                cmd += ['--add-drivers', 'f2fs']
+            print('using this command:\n%s' % cmd)
+            call(cmd)
+            a = os.path.join(d, vm)
+            imagedirs = [os.path.join(self.srcdir, 'syslinux'),
+                os.path.join(self.srcdir, 'images', 'pxeboot'),
+                os.path.join(self._LiveImageCreatorBase__isodir, 'isolinux'),
+                os.path.join(self._LiveImageCreatorBase__isodir, 'images',
+                             'pxeboot')]
+            if not os.access(imagedirs[1], os.W_OK):
+                del imagedirs[0:2]
+            [shutil.copy2(rc, os.path.join(d, img)) for d in imagedirs]
+            [shutil.copy2(a, os.path.join(d, vm)) for d in imagedirs]
+        if msg == 'update':
+            return
+
+        print('Checking kernel versions in %s...' % msg)
+        c = os.getcwd()
+        os.chdir('/tmp')
+        if os.path.exists('usr'):
+            shutil.rmtree('usr')
+        cmd = ['lsinitrd', self.initrd, '--unpack', '--file', os.path.join(
+               'usr', 'lib', 'modules', '*', 'kernel'), '-v', '2>&1']
+        a, initrd_kernel, rc = rcall(cmd)
+        os.chdir(c)
+        self.initrd_kernel = os.path.basename(os.path.dirname(
+                                              initrd_kernel.rstrip()))
+        a = rc = ''
+        if self.kernel_release not in self.kernels:
+            a = '''
+          * This version is not among those installed in the root filesystem:
+            \r%s''' % '\n'.join(self.kernels)
+        if self.kernel_release != self.initrd_kernel:
+            rc = '''
+          * There is a mismatch between the kernel and initial ram filesystem.
+            \r'''
+        if a or rc:
+            s = input('''\nTAKE NOTE:  The %s boot loader invokes kernel version
+           '%s'
+            using an initial ram filesystem compiled with kernel
+           '%s'
+          %s
+          %s
             The kernel may have been upgraded or reside in an overlay.
-            If the boot kernel version is not available in the root filesystem,
-            the booted operating system will most likely fail.\n
-            Enter 'a' to abort or just press Enter to continue...
-            ''' % (self.kernel_release, '\n'.join(kernels)))
+            If the boot kernel version is not available in the root filesystem
+            or match the initial ram filesystem version, the booted operating
+            system will most likely fail.\n
+            Enter 'a' to abort, or
+            Enter 's' to launch a shell, or
+            just press Enter to continue...
+            ''' % (msg, self.kernel_release, self.initrd_kernel, a, rc))
             if s == 'a':
                 raise CreatorError('''Aborting edit due to mismatching kernels.
                 Exiting...''')
+            elif s == 's' and 'current' in msg:
+                self.shell = True
+            elif s == 's':
+                self.launch_shell()
+                self.check_kernel_versions(isodir, msg)
 
 
     def _brand(self, isodir):
@@ -1519,6 +1586,12 @@ class LiveImageEditor(LiveImageCreator):
                         os.fsync(f.fileno())
                         f.close()
             self.releasefile = nametext
+
+        sedscript = r'''/^\s*label\s+linux/I {n;n;n
+                      s/^\s*append\s+initrd=\S+\s+(.*)/\1/Ip;q}'''
+        cmd[3:] = [sedscript, self.cfgf]
+        self.kcmdline0, err, rc = rcall(cmd)
+        self.kcmdline0 = self.kcmdline0.rstrip()
 
 
     def _configure_bootloader(self, isodir):
@@ -1990,11 +2063,8 @@ s/\s+$//}}'''
         else:
             _proclists('squashfs.img', self.rootfs_img, rootfsimg)
 
-        syslinuxdir = os.path.join(self.liveosdir, 'syslinux')
-        if not os.path.isdir(syslinuxdir):
-            syslinuxdir = os.path.join(self.srcmntdir, 'syslinux')
         for f in ('syslinux.cfg', 'extlinux.conf'):
-            cfgf = os.path.join(syslinuxdir, f)
+            cfgf = os.path.join(self.bootfolder, f)
             if os.path.exists(cfgf): break
         shutil.copy2(cfgf, cfgf + '.prev')
         cmd = ['sed', '-i', '-r',]
@@ -2003,7 +2073,7 @@ s/\s+$//}}'''
                      self.release, self.releasefile), cfgf]
         call(cmd)
 
-        if os.path.dirname(syslinuxdir) != self.srcmntdir:
+        if os.path.dirname(self.bootfolder) != self.srcmntdir:
             e = os.path.basename(self.liveosdir.rstrip('/'))
             dn = ''
             for c in e:
@@ -2131,13 +2201,13 @@ s/\s+$//}}'''
             else:
                 p = False
             e.cleanup()
-            return p
+            return [p, e]
 
         for p in [[p2, 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'],
                   [p3, '48465300-0000-11aa-aa11-00306543ecac']]:
             c = lsblk('-no NAME,PARTTYPE', p[0][0]).split()
             if c and c[1] == p[1]:
-                p[0] += [cp_cfg(p[0][0])]
+                p[0] += cp_cfg(p[0][0])
             else:
                 p[0][0] = ''
                 p[0] += [False]
@@ -2154,15 +2224,55 @@ s/\s+$//}}'''
                                                   self.ovl_blksz)
             self.liveosmnt.cleanup()
             self.liveosmnt.overlay = overlay[0]
-            cmd[3:] = [r'''s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/
+            cmd[3:] = [r'''/^\s*append/ {{
+            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/
+            :w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw}}
             '''.format(overlay[1]), cfgf]
             call(cmd)
             cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
-            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={1}/}}
+            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={1}/
+            :w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw}}
             '''.format(dn, overlay[1]), EFI_config]
             call(cmd)
         elif self.ovltype != 'DM_linear':
             self.liveosmnt.reset_overlay()
+
+        cmd = ['sed', '-n', '-r']
+        sedscript = r'''/^\s*label\s+linux/I {n;n;n
+                      s/^\s*append\s+initrd=\S+\s+(.*)/\1/Ip;q}'''
+        cmd.extend([sedscript, cfgf])
+        kcmdline, err, rc = rcall(cmd)
+        kcmdline = kcmdline.rstrip()
+        self.kernel_release = get_file_info(self.kernel)[7]
+
+        if self.src_fstype == 'f2fs' and p2[0]:
+            d, err, rc = rcall(['dump.f2fs', self.src_partition])
+            if 'extra_attr' in d:
+                p2[2].mount()
+                d = p2[2].mountdir
+                if dn == ' ':
+                    dn = 'LiveOS'
+                e = os.path.join(d, 'linux_' + dn + '.efi')
+                cmd = ['sed', '-znr']
+                cmd[2:] = [r'''1,/^[0-9]+\.[0-9]+\.[0-9]+/ {
+                s/^([0-9]+\.[0-9]+\.[0-9]+\S+)\s+.*/\1/p}''', e]
+                efistub_kernel, err, rc = rcall(cmd)
+                efistub_kernel = efistub_kernel.rstrip('\x00')
+
+                if (kcmdline != self.kcmdline0 or (efistub_kernel and
+                    self.kernel_release != efistub_kernel)):
+                    self.liveosmnt.mount()
+                    dracut_cmd = ['dracut', e, '--uefi', '--kmoddir',
+                    os.path.join(self.liveosmnt.mountdir, 'usr', 'lib',
+                    'modules', self.kernel_release), '--kver',
+                    self.kernel_release, '--no-machineid', '--kernel-image',
+                    os.path.join(self.bootfolder, 'vmlinuz'), '--no-hostonly',
+                    '--add', 'dmsquash-live', '--add-drivers', 'f2fs',
+                    '--kernel-cmdline', kcmdline, '--force']
+                    print('\nUpdating %s using this command:\n\n%s' %
+                          (os.path.basename(e), dracut_cmd))
+                    call(dracut_cmd)
+                p2[2].cleanup()
 
         if self.seclude_tar:
             print('Restoring secluded files to the refresh...')
@@ -2338,6 +2448,7 @@ def main():
 
     name = ''.join((os.path.basename(args.liveos.rstrip('/')), '.edited'))
     src_type = 'iso'
+    src_fstype = 'iso9660'
     if args.liveos == 'live' or args.liveos in (
                  '/mnt/live', '/run/initramfs/live', '/run/initramfs/livedev'):
         src_type = 'live'
@@ -2389,6 +2500,7 @@ def main():
     editor = LiveImageEditor(name, docleanup=not args.nocleanup)
     editor.src = args.liveos
     editor.src_type = src_type
+    editor.src_fstype = src_fstype
     editor.exclude_all = False
     if args.excludes:
         editor.excludes = args.excludes.split()
@@ -2439,9 +2551,10 @@ def main():
             editor.ovl_blksz = ovlfs[2]
         except IndexError:
             editor.ovl_blksz = 4096
-        if editor.ovl_fstype == 'dir' and src_fstype in ('vfat', 'msdos'):
+        if editor.ovl_fstype == 'dir' and editor.src_fstype in ('vfat',
+                                                                'msdos'):
             print("\nNOTICE:\tAn unembedded directory overlay is unsuitable\n"
-                  "\tfor the '%s'-based device '%s'.\n" % (src_fstype,
+                  "\tfor the '%s'-based device '%s'.\n" % (editor.src_fstype,
                   args.liveos), file=sys.stderr)
             return 1
     editor.refresh_only = args.refresh_only
@@ -2487,12 +2600,17 @@ def main():
                                                    editor.ks)
         editor._pre_mount(args.liveos, args.rootfsimg, args.overlay)
         editor.mount(editor.cachedir)
-        if editor.refresh_only:
-            isodir = os.path.join(editor.srcmntdir, 'syslinux')
-        else:
+        isodir = editor.bootfolder
+        editor.kernels = None
+        editor.check_kernel_versions(editor.bootfolder, 'current image')
+        editor.check_kernel_versions(os.path.join(editor.srcdir, 'images',
+            'pxeboot'), 'current .iso')
+        editor.kernel_version0 = editor.kernel_release
+        editor.initrd_kernel0 = editor.initrd_kernel
+        editor.kernels0 = editor.kernels
+        if not editor.refresh_only:
             isodir = os.path.join(editor._LiveImageCreatorBase__isodir,
                                   'isolinux')
-        editor.check_kernel_versions(isodir)
         editor._brand(isodir)
         if not editor.refresh_only:
             editor._configure_bootloader(editor._LiveImageCreatorBase__isodir)
@@ -2504,12 +2622,24 @@ def main():
         elif args.script:
             print("Running edit script '%s'" % args.script)
             editor._run_script(args.script)
-        elif editor.shell:
-            print("Launching shell. Exit (Ctrl D) to continue.")
-            print("-------------------------------------------")
+        if editor.shell:
+            print('''Launching shell. Exit (Ctrl D) to continue.
+                  \r-------------------------------------------''')
             ops = None
             editor.launch_shell()
 
+        editor.kernels = None
+        editor.check_kernel_versions(isodir, 'update')
+        if not editor.refresh_only:
+            editor.check_kernel_versions(os.path.join(
+                editor._LiveImageCreatorBase__isodir, 'images', 'pxeboot'),
+                'new .iso')
+            editor.check_kernel_versions(isodir, 'new install image')
+        if ((not editor.src_type == 'iso' or editor.skip_refresh) and
+            not hasattr(editor, 'isosrcmnt')):
+            editor.check_kernel_versions(os.path.join(editor.srcdir,
+                'images', 'pxeboot'), 'source PXE')
+            editor.check_kernel_versions(editor.bootfolder, 'source image')
         if editor.liveosmnt:
             if editor.refresh_only:
                 editor.liveosmnt.cleanup()
@@ -2569,21 +2699,22 @@ def main():
             editor.liveosmnt.cleanup()
         editor.cleanup()
         if (editor.src_type == 'live' and not editor.skip_refresh and
-         src_fstype == 'vfat' and os.access(editor.liveosmnt.srcdir, os.W_OK)):
+         editor.src_fstype == 'vfat' and os.access(editor.liveosmnt.srcdir,
+                                                   os.W_OK)):
             print('''
             NOTICE:  Please shut down and run fsck.vfat on this device's
                      partition, '%s', to reclaim storage clusters that were
                      unlinked during the LiveOS and overlay refresh.
                   ''' % editor.src_partition)
-        if editor.src_type not in ('dir', 'live') and os.path.ismount(
-        editor.srcmntdir):
-            os.system('umount --detach-loop ' + editor.srcmntdir)
+        if (editor.src_type not in ('dir', 'live') and editor.srcmntdir
+            and os.path.ismount(editor.srcmntdir)):
+            os.system('umount ' + editor.srcmntdir)
         if hasattr(editor, 'isosrcmnt'):
             editor.isosrcmnt.unmount()
             editor.liveossrc.cleanup()
         if (success and not editor.skip_refresh and
             not editor.src_type in ('live', 'iso')):
-            editor._fsck_img(editor.src_partition, src_fstype)
+            editor._fsck_img(editor.src_partition, editor.src_fstype)
         if success and editor.docleanup and editor.src_type != 'iso':
             shutil.rmtree(editor.mntdir)
         print('\nLiveOS edit has ended.')

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -146,7 +146,9 @@ parser.add_argument('-S', '--skip-SELinux', dest='force_selinux',
 
 parser.add_argument('-s', '--script', metavar='PATH',
                     help='Specify a script to run chrooted in the LiveOS\n'
-                         'filesystem hierarchy.\n ')
+                         'filesystem hierarchy.  A bind mount to the host\n'
+                         'filesystem root has been prepared at /run/hostroot\n'
+                         'in the chroot for easy access to host files.\n ')
 
 parser.add_argument('-N', '--noshell', dest='shell', action='store_false',
                     default=True,
@@ -566,6 +568,7 @@ class LiveImageEditor(LiveImageCreator):
 
         ops = ''
         f = ''  # variable & flag for iso-scan/filename booted host.
+        self.ovl_size = 0
         if self.src_type in ('live', 'OFS'):
             src = os.path.join('/run', 'initramfs', 'isoscandev')
                 # (^ Requires dracut verion 051 or greater.)
@@ -586,7 +589,7 @@ class LiveImageEditor(LiveImageCreator):
                 self.skip_refresh = True
                 self.liveosmnt = self.new_liveos_mount(base_on, '/',
                         '/run/overlayfs', self.mntdir, ops='ro', dirmode=0o700)
-                self.srcmntdir = lsblk('-no MOUNTPOINT', '/dev/loop0')
+                self.srcmntdir = self.srcdir
             if not f:
                 base_on = os.path.dirname(losetup('-nO BACK-FILE', '/dev/loop0'))
                 self.srcmntdir = '/run/initramfs/live'
@@ -603,7 +606,7 @@ class LiveImageEditor(LiveImageCreator):
                               'lowerdir=')+9:src[1].find(',upperdir=')]
                     self._overlay = src[1][src[1].find(
                                     'upperdir=')+9:src[1].find(',workdir=')]
-                    if not f:
+                    if not f and os.path.islink(self._overlay):
                         self._overlay = os.path.dirname(
                                             os.path.realpath(self._overlay))
                         self.overlayloop = findmnt('-no SOURCE', self._overlay)
@@ -611,6 +614,8 @@ class LiveImageEditor(LiveImageCreator):
                             self.srcdir = os.path.join(self.srcmntdir,
                                        os.path.dirname(losetup('-nO BACK-FILE',
                                           self.overlayloop)).lstrip(os.sep))
+                    if not os.path.islink(self._overlay):
+                        self.ovltype = 'tempdir'
                     self.imgloop = findmnt('-no SOURCE', base_mp)
             else:
                 self.liveosdir = base_on
@@ -1403,7 +1408,8 @@ class LiveImageEditor(LiveImageCreator):
                           (cachesrc, '/var/cache/dnf'),
                           (cachesrc, '/var/cache/yum'),
                           (self._LiveImageCreatorBase__isodir, '/mnt/live'),
-                          (self.srcmntdir, '/run/initramfs/live')]
+                          (self.srcmntdir, '/run/initramfs/live'),
+                          ('/', '/run/hostroot')]
             if self.force_selinux:
                 bindmounts += [(self._ImageCreator__selinux_mountpoint, None)]
             for (f, dest) in bindmounts:
@@ -1429,9 +1435,9 @@ class LiveImageEditor(LiveImageCreator):
         Check that the kernel version in the root filesystem matches that
         called by the boot loader.
         """
-        kernel = os.path.join(isodir, 'isolinux', 'vmlinuz')
+        kernel = os.path.join(isodir, 'vmlinuz')
         if not os.path.exists(kernel):
-            kernel = os.path.join(isodir, 'isolinux', 'vmlinuz0')
+            kernel = os.path.join(isodir, 'vmlinuz0')
         self.kernel_release = get_file_info(kernel)[7]
         kernels = os.listdir(os.path.join(self._instroot, 'usr', 'lib',
                                           'modules'))
@@ -1456,12 +1462,12 @@ class LiveImageEditor(LiveImageCreator):
         source by name, builder, and build date.
         """
         for f in ('isolinux.cfg', 'syslinux.cfg', 'extlinux.conf'):
-            self.cfgf = os.path.join(isodir, 'isolinux', f)
+            self.cfgf = os.path.join(isodir, f)
             if os.path.exists(self.cfgf): break
         # Get release name from boot configuration file.
         cmd = ['sed', '-n', '-r']
-        sedscript = r'''/^\s*label\s+linux/{n
-                        s/^\s*menu\s+label\s+\^(Start|Install)\s+(.*)/\2/p}'''
+        sedscript = r'''/^\s*label\s+linux/I {n
+                      s/^\s*menu\s+label\s+\^\S+\s+(.*)/\1/Ip;q}'''
         cmd.extend([sedscript, self.cfgf])
         release, err, rc = rcall(cmd)
         if not release:
@@ -1556,26 +1562,20 @@ class LiveImageEditor(LiveImageCreator):
         call(cmd)
 
         sedscript = r'''s/(root=[^ ]*|inst.stage2=[^ ]*)/root=live:CDLABEL={0}/
-                     '''.format(self.fslabel)
-        cmd[3:] = [sedscript, isocfgf]
+s/^\s*timeout\s+.*/timeout 600/I
+/^\s*totaltimeout\s+.*/Iz
+s/\<{1}\>/{2}/g
+/^\s*append|linuxefi/I s/\<rd\.live\.[^c]\S+\s+//2g
+'''.format(self.fslabel, self.release, self.releasefile)
+        cmd = ['sed', '-i', '-r', sedscript, isocfgf]
         if EFI_config:
             cmd.append(EFI_config)
         call(cmd)
-        sedscript = r'''s/^\s*timeout\s+.*/timeout 600/I
-/^\s*totaltimeout\s+.*/Iz
-s/{0}/{1}/'''.format(self.release, self.releasefile)
-        cmd[3:] = [sedscript, isocfgf]
-        call(cmd)
 
-        if self.releasefile:
-            sedscript = r'''1,20 s/^(\s*menu\s+title\s+)(Welcome\s+to|.+)/\1{}/I
-'''.format(self.releasefile)
-        sedscript += r'''s/\<(kernel)\>\s+[^\n.]*(vmlinuz.?)/\1 \2/
+        sedscript = r'''s/\<(kernel)\>\s+\S*(vmlinuz.?)/\1 \2/
+/\s+append/I {{
 s/\<(initrd=).*(initrd.?\.img)\>/\1\2/
-s/\<(root=live:[^ ]*)\s+[^\n.]*\<(rd\.live\.image|liveimg)/\1 \2/
-/^\s*label\s+linux\>/I,/^\s*label\s+check\>/Is/(rd\.live\.image|liveimg).*/\1 quiet/
-/^\s*label\s+check\>/I,/^\s*label\s+vesa\>/Is/(rd\.live\.image|liveimg).*/\1 rd.live.check quiet/
-/^\s*label\s+vesa\>/I,/^\s*label\s+memtest\>/Is/(rd\.live\.image|liveimg).*/\1 nomodeset quiet/'''
+s/\s+rw\>//g}}'''
         cmd[3:] = [sedscript, isocfgf]
         call(cmd)
 
@@ -1586,44 +1586,44 @@ s/\<(root=live:[^ ]*)\s+[^\n.]*\<(rd\.live\.image|liveimg)/\1 \2/
             sedscript = r'''/^\s*insmod\s+(fat|xfs|f2fs|btrfs)\s*$/ s/(fat|xfs|f2fs|btrfs)/ext2/
 s/(--set=root ).+'/\1-l '{0}'/
 s/^\s*set\s+timeout=.*/set timeout=60/
-/^\s*menuentry\s+'(Start|Install)\s+/,/\s*\}}/ {{s/\s+'(Start|Install)\s+.+'/ 'Start {1}'/
-s/(rd\.live\.image|liveimg).*/\1 quiet/}}
-/^\s*menuentry\s+'Test\s+/,/\s*}}/ {{s/\s+&\s+(start|install)\s+.+'/ \& start {1}'/
-s/(rd\.live\.image|liveimg).*/\1 rd.live.check quiet/}}
-/^\s*submenu\s+'Trouble/,/\s*}}/ {{s/(menuentry\s+').+'/\1Start {1} in basic graphics mode'/
-s/(rd\.live\.image|liveimg).*/\1 nomodeset quiet/}}
-s/(linuxefi\s+[^ ]+vmlinuz.?)\s+.*\s+(root=live:[^\s+]*)/\1 \2/
-s_(linuxefi|initrdefi)\s+[^ ]+(initrd.?\.img|vmlinuz.?)_\1 /{2}/\2_
-s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
+s_(linuxefi|initrdefi)\s+\S+(vmlinuz.?|initrd.?\.img)_\1 /{1}/\2_
+/^\s*menuentry/ {{
+s/\S+\s+~{2}/{2}/
+s/\s+rw\>//g}}'''.format(self.fslabel, iso_boot, self.releasefile)
             cmd[3:] = [sedscript, EFI_config]
             call(cmd)
 
-        sedscript = ''
+        sedscript = r'''/^\s*append|linuxefi/I {{
+'''
         if self.flatten_squashfs:
-            self.kernelargs += ' rd.live.overlay.overlayfs'
+            self.kernelargs = 'rd.live.overlay.overlayfs ' + self.kernelargs
         if self.kernelargs:
-            sedscript = r's/(rd\.live\.image|liveimg)/\1 %s /' % self.kernelargs
+            sedscript += r'''s/\s+(rd\.live\.image|liveimg)(.*)$/ \1 {0} \2/
+'''.format(self.kernelargs)
         if self.ks:
             # bootloader --append "!opt-to-remove opt-to-add"
             for param in kickstart.get_kernel_args(self.ks, "").split():
                 if param.startswith('!'):
                     param=param[1:]
                     # remove parameter prefixed with !
-                    sedscript += r'\n/^  append/s/%s //\n' % param
-                    # special case for last parameter
-                    sedscript += r'/^  append/s/%s$//\n' % param
+                    sedscript += r'''s/ %s\>//
+''' % param
                 else:
                     # append parameter
-                    sedscript += r'\n/^  append/s/$/ %s/' % param
-        if sedscript:
-            cmd[3:] = [sedscript, isocfgf]
-            if EFI_config:
-                cmd.append(EFI_config)
+                    sedscript += r'''s/$/ %s/
+''' % param
 
-            try:
-                call(cmd)
-            except IOError as e:
-                raise CreatorError("Failed to configure bootloader file: %s" % e)
+        sedscript += r''':w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw
+s/\>\s\s+/ /g
+s/\s+$//}}'''
+        cmd[3:] = [sedscript, isocfgf]
+        if EFI_config:
+            cmd.append(EFI_config)
+
+        try:
+            call(cmd)
+        except IOError as e:
+            raise CreatorError("Failed to configure bootloader file: %s" % e)
 
         # Clear remnants of a multi boot install.
         EFI_config = os.path.join(isodir, 'EFI', 'BOOT', 'grub.cfg.prev')
@@ -1999,30 +1999,24 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
         shutil.copy2(cfgf, cfgf + '.prev')
         cmd = ['sed', '-i', '-r',]
         cmd[3:] = [
-        r'''/^\s*label\s+linux\>/I,/^\s*label\s+memtest\>/I s/{0}/{1}/'''.format(
+        r'''/^\s*menu\s+title\>/I,/^\s*label\s+memtest\>/I s/{0}/{1}/'''.format(
                      self.release, self.releasefile), cfgf]
         call(cmd)
 
-        cmd = ['sed', '-n', '-r',
-                r'/^\s*menu\s+title\s+Multi Live Image Boot Menu/p', cfgf]
-        f, e, c = rcall(cmd)
-        if not f:
-            cmd = ['sed', '-i', '-r',
-            r'''1,20 s/^(\s*menu\s+title\s+)(Welcome\s+to|.+)/\1{}/I'''.format(
-                self.releasefile), cfgf]
-            call(cmd)
-
         if os.path.dirname(syslinuxdir) != self.srcmntdir:
-            dn = e = os.path.basename(self.liveosdir.rstrip('/'))
-            for c in ('?', '+', '/', '|', '{', '}'):
-                if c in e:
-                    dn = e.replace(c, '\\' + c)
+            e = os.path.basename(self.liveosdir.rstrip('/'))
+            dn = ''
+            for c in e:
+                if c in r']\/;$*.^?+|{}&[':
+                    dn += '\\' + c
+                else:
+                    dn += c
 
             f = cfgf.replace(e + os.sep, '')
             shutil.copy2(f, f + '.prev')
-            cmd[3:] = [r'''/\s*label\s+{0}/I {{N;
-            /{0}/ s/(Start\s+).+( menu)/\1{1}\2/}}'''.format(
-                       dn, self.releasefile), f]
+            cmd[3:] = [r'''/^\s*label\s+{0}/I {{N;
+                      /{0}/ s/{1}/{2}/}}'''.format(
+                       dn, self.release, self.releasefile), f]
             call(cmd)
         else:
             dn = ' '
@@ -2032,10 +2026,11 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
                                       'EFI', c, 'grub.cfg')
             if os.path.exists(EFI_config):
                 break
+        EFI_dir = os.path.join('EFI', c)
         shutil.copy2(EFI_config, EFI_config + '.prev')
         c = os.path.join(os.path.dirname(EFI_config), 'BOOT.conf')
         shutil.copy2(c, c + '.prev')
-        cmd[3:] = [r'''/menuentry/ {{N;
+        cmd[3:] = [r'''/^\s*menuentry/ {{N;
         /{0}\/syslinux\/vmlinuz/ s/{1}/{2}/}}'''.format(
                     dn, self.release, self.releasefile), EFI_config]
         call(cmd)
@@ -2069,7 +2064,7 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
                 self.ovl_blksz = os.statvfs(
                 '/run/initramfs/overlayfs/overlayfs').f_bsize
 
-        if (self.flatten_squashfs and self.ovltype in ('', 'temp',
+        if (self.flatten_squashfs and self.ovltype in ('', 'temp', 'tempdir',
             'DM_snapshot_cow')) or (self.overlay_size_mb and
             self.ovltype in ('', 'DM_snapshot_cow', 'DM_linear') and
             self.ovl_fstype not in ('', 'temp','DM_snapshot_cow')):
@@ -2088,9 +2083,9 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
             's/rd\.live\.image|liveimg/& rd.live.overlay.overlayfs/', cfgf]
             call(cmd)
 
-            cmd[3:] = [
-            r's/{0}\/syslinux\/vmlinuz/& rd.live.overlay.overlayfs/'.format(dn)
-                        , EFI_config]
+            cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
+            s/rd\.live\.image|liveimg/& rd.live.overlay.overlayfs/}}
+            '''.format(dn), EFI_config]
             call(cmd)
 
         elif self.overlay_size_mb and self.ovl_fstype == 'DM_snapshot_cow':
@@ -2102,17 +2097,70 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
             call(cmd)
         shutil.copy2(EFI_config, c)
 
+        self.src_partition = findmnt('-no SOURCE', self.srcmntdir)
+
+        c = lsblk('-no NAME,PKNAME', self.src_partition).split()
+        d = '/dev/' + c[1]
+        p = c[0][len(c[1]):]
+        if p[0] == 'p':
+            p = p[1:]
+            s = 'p'
+        else:
+            s = ''
+
+        p = int(p)
+        p2 = [d + s + str(p + 1)]
+        p3 = [d + s + str(p + 2)]
+
+        def cp_cfg(p):
+            e = DiskMount(RawDisk(None, p),
+                          tempfile.mkdtemp(dir=self.mntdir, prefix='efi-'),
+                          dirmode=0o700)
+            e.mount()
+            d = e.mountdir
+            if os.access(d, os.W_OK):
+                for f in ('BOOT.conf.prev', 'grub.cfg.prev'):
+                    shutil.copy2(EFI_config + '.prev',
+                                 os.path.join(d, EFI_dir, f))
+                for f in ('BOOT.conf', 'grub.cfg'):
+                    shutil.copy2(EFI_config, os.path.join(d, EFI_dir, f))
+                if p == p3[0]:
+                    shutil.copy2(EFI_config, os.path.join(d, 'System',
+                                        'Library', 'CoreServices', 'grub.cfg'))
+                p = True
+            else:
+                p = False
+            e.cleanup()
+            return p
+
+        for p in [[p2, 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'],
+                  [p3, '48465300-0000-11aa-aa11-00306543ecac']]:
+            c = lsblk('-no NAME,PARTTYPE', p[0][0]).split()
+            if c and c[1] == p[1]:
+                p[0] += [cp_cfg(p[0][0])]
+            else:
+                p[0][0] = ''
+                p[0] += [False]
+
         self.liveosmnt = self.new_liveos_mount(self.src, args.rootfsimg,
                                                overlay, self.mntdir)
         self.liveosmnt._LiveImageMount__create(ops='rw', dirmode=0o700)
 
         if self.overlay_size_mb:
+            self.liveosmnt.overlay = None
             overlay = self.liveosmnt.make_overlay(self.overlay_size_mb,
                                                   self.ovl_size,
                                                   self.ovl_fstype,
                                                   self.ovl_blksz)
             self.liveosmnt.cleanup()
-            self.liveosmnt.overlay = overlay
+            self.liveosmnt.overlay = overlay[0]
+            cmd[3:] = [r'''s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/
+            '''.format(overlay[1]), cfgf]
+            call(cmd)
+            cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
+            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={1}/}}
+            '''.format(dn, overlay[1]), EFI_config]
+            call(cmd)
         elif self.ovltype != 'DM_linear':
             self.liveosmnt.reset_overlay()
 
@@ -2136,6 +2184,10 @@ s/\s+rw\s+|\s+rw$/ /g'''.format(self.fslabel, self.releasefile, iso_boot)
         self.liveosmnt.cleanup()
         if self.liveossrc:
             self.liveossrc.cleanup()
+        if p2[0] and p2[1]:
+            self._fsck_img(p2[0], 'vfat')
+        if p3[0] and p3[1]:
+            self._fsck_img(p3[0], 'hfsplus')
 
 
     def _fsck_img(self, img, fstype):
@@ -2311,7 +2363,7 @@ def main():
                 src = findmnt('-no TARGET', args.liveos).split('\n')
                 if src in ('/run/initramfs/live', '/mnt/live'):
                     src_type = 'live'
-            src_fstype = findmnt('-no FSTYPE -S', args.liveos)
+            src_fstype = lsblk('-no FSTYPE', args.liveos)
             name = ''.join((findmnt('-no LABEL', args.liveos), '.edited'))
         elif stat.S_ISREG(st_mode) and args.overlay_size_mb:
             print("\nNOTICE:  An overlay is unsuitable for '%s'.\n" % 
@@ -2435,9 +2487,14 @@ def main():
                                                    editor.ks)
         editor._pre_mount(args.liveos, args.rootfsimg, args.overlay)
         editor.mount(editor.cachedir)
-        editor.check_kernel_versions(editor._LiveImageCreatorBase__isodir)
+        if editor.refresh_only:
+            isodir = os.path.join(editor.srcmntdir, 'syslinux')
+        else:
+            isodir = os.path.join(editor._LiveImageCreatorBase__isodir,
+                                  'isolinux')
+        editor.check_kernel_versions(isodir)
+        editor._brand(isodir)
         if not editor.refresh_only:
-            editor._brand(editor._LiveImageCreatorBase__isodir)
             editor._configure_bootloader(editor._LiveImageCreatorBase__isodir)
         if editor.ks:
             # Run_pre_scripts same code as ImageCreator_run_post_scripts
@@ -2511,27 +2568,29 @@ def main():
         if editor.liveosmnt:
             editor.liveosmnt.cleanup()
         editor.cleanup()
+        if (editor.src_type == 'live' and not editor.skip_refresh and
+         src_fstype == 'vfat' and os.access(editor.liveosmnt.srcdir, os.W_OK)):
+            print('''
+            NOTICE:  Please shut down and run fsck.vfat on this device's
+                     partition, '%s', to reclaim storage clusters that were
+                     unlinked during the LiveOS and overlay refresh.
+                  ''' % editor.src_partition)
+        if editor.src_type not in ('dir', 'live') and os.path.ismount(
+        editor.srcmntdir):
+            os.system('umount --detach-loop ' + editor.srcmntdir)
+        if hasattr(editor, 'isosrcmnt'):
+            editor.isosrcmnt.unmount()
+            editor.liveossrc.cleanup()
+        if (success and not editor.skip_refresh and
+            not editor.src_type in ('live', 'iso')):
+            editor._fsck_img(editor.src_partition, src_fstype)
+        if success and editor.docleanup and editor.src_type != 'iso':
+            shutil.rmtree(editor.mntdir)
         print('\nLiveOS edit has ended.')
 
         h, m = divmod(time.time() - t0, 3600)
         m, s = divmod(m, 60)
         print('Process duration: %02d:%02d:%02d' % (h, m, s))
-
-        if editor.src_type == 'live' and not editor.skip_refresh and findmnt(
-        '-no FSTYPE -T', editor.srcmntdir) == 'vfat' and os.access(
-        editor.liveosmnt.srcdir, os.W_OK):
-            print('''
-            NOTICE:  Please shut down and run fsck.vfat on this device's
-                     partition to reclaim storage clusters that were unlinked
-                     during the LiveOS and overlay refresh.
-                  ''')
-        if editor.src_type == 'blk' and os.path.ismount(editor.srcmntdir):
-            os.system('umount --detach-loop ' + editor.srcmntdir)
-        if hasattr(editor, 'isosrcmnt'):
-            editor.isosrcmnt.unmount()
-            editor.liveossrc.cleanup()
-        if success and editor.docleanup and editor.src_type != 'iso':
-            shutil.rmtree(editor.mntdir)
 
     return 0
 


### PR DESCRIPTION
### 1. Preserve extra-kernel-args from source
Preserve any extra kernel arguments that have been added by editliveos
or manually to the source boot configuration files.
Also:
 - Add a bind mount to the host root filesystem for editliveos --script
   or shell so as to ease access to host files from the install chroot.
 - Improve some error handling & reporting.
 - Adjust some space accounting & reporting for filesystem variations.
 - Enable the ext4 64bit feature if the host's SYSLINUX version >= 6.04
 - Update all boot configuration files upon editliveos refresh.
 - fsck filesystems upon editliveos refresh.
 - Fix a --refresh-only bug in editliveos.

### 2. Refresh vmlinuz & initrd.img upon kernel updates
Detect when a new kernel has been installed and update the working
copies to the newer version for both the new .iso image and a
refreshable source, including a currently booted LiveOS image. (The
new versions will be active on the next boot.)

 - Enhance kernel version checking in livecd-iso-to-disk to test
   for matching versions in the kernel and initial RAM filesystems.
 - Mount macboot.img and copy its files rather than using dd on the
   whole image. This proved to be more robust during fsck.hfsplus.
 - Copy proper image & syslinux directories on multi-image sources.
 - Preserve mode, ownership, timestamps on more copy calls.
 - Add some line breaks to separate transcript sections.
 - Add a missing import to util.py.
 - Update documentation.