### PR TITLE
livecd-iso-to-disk, editliveos: Add option to skip macboot.img proces…

### DIFF
--- a/docs/livecd-iso-to-disk.pod
+++ b/docs/livecd-iso-to-disk.pod
@@ -92,6 +92,10 @@ Skips the formatting of a secondary EFI System Partition and an Apple HFS+ boot 
 
 Note: Even with this option, EFI components are configured and loaded on the primary partition if they are present on the source.
 
+=item --nomac    (Used with --format)
+
+Skips the formatting of an Apple HFS+ boot partition.  Useful when hfsplus-tools are not available.
+
 =item --reset-mbr|--resetmbr
 
 Sets the Master Boot Record (MBR) of the target storage device to the F<mbr.bin> or F<gptmbr.bin> file from the installation system's F<syslinux> directory.  This may be helpful in recovering a damaged or corrupted device.  Also sets the legacy_boot flag on the primary partition for GPT disks.
@@ -162,6 +166,32 @@ Skip the boot menu, and automatically boot the 'linux' label item.
 
 Specifies additional kernel arguments, <arg s>, that will be inserted into the syslinux and EFI boot configurations.  Multiple arguments should be specified in one string, I<i.e.>, --extra-kernel-args "arg1 arg2 ..."
 
+=item --overlay-size-mb <size>[,fstype[,blksz]]
+
+Specifies creation of a filesystem overlay of <size> mebibytes (integer values only).  [fstype] and [blksz] are relevant only for creating OverlayFS overlay filesystems on vfat-formatted primary devices.  An overlay makes persistent storage available to the live operating system, if permitted and installed on writable media.  The overlay holds a snapshot of changes to the root filesystem.
+
+B<Note well> that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent F</LiveOS/overlay-<device_id>> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to the restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the C<dmsetup status> command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, see --home-size-mb below.  The target storage device must have enough free space for the image and the overlay.  A maximum <size> of 4096 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
+
+=item --overlayfs [temp]   (add --overlay-size-mb for persistence on vfat devices)
+
+Specifies the creation of an OverlayFS type overlay.  If the option is followed by C<temp>, a temporary overlay will be used.  On vfat or msdos formatted devices, --overlay-size-mb <size> must also be provided for a persistent overlay.  OverlayFS overlays are directories of the files that have changed on the read-only root filesystem.  With non-vfat-formatted devices, the OverlayFS can extend the available root filesystem space up to the capacity of the Live USB device.
+
+The --overlayfs option requires an initial boot image based on dracut version 045 or greater to use the OverlayFS feature.  Lacking this, the device boots with a temporary Device-mapper overlay.
+
+=item --copy-overlay
+
+This option allows one to copy the persistent overlay from one live image to the new image.  Changes already made in the source image will be propagated to the new installation.
+
+=over 4
+
+B<WARNING:>  User sensitive information such as password cookies and application or user data will be copied to the new image!  Scrub this information before using this option.
+
+=back
+
+=item --reset-overlay
+
+This option will reset the persistent overlay to an unallocated state.  This might be used if installing a new or refreshed image onto a device with an existing overlay, and avoids the writing of a large file on a vfat-formatted device.  This option also renames the overlay to match the current device filesystem label and UUID.
+
 =item --compress    (default state for the original root filesystem)
 
 The default, compressed SquashFS filesystem image is copied on installation.  (This option has no effect if the source filesystem is already expanded.)
@@ -174,32 +204,6 @@ Expands the source F<squashfs.img> on installation into the read-only F</LiveOS/
 
 Installs a kernel option, C<rd.live.overlay=none>, that signals the live boot process to create a writable, linear Device-mapper target for an uncompressed F</LiveOS/rootfs.img> filesystem image file.  Read-write by default (unless a kernel argument of C<rd.live.overlay.readonly> is given) this configuration avoids the complications of using an overlay of fixed size for persistence when storage format and space allows.
 
-=item --overlayfs [temp]   (add --overlay-size-mb for persistence on vfat devices)
-
-Specifies the creation of an OverlayFS type overlay.  If the option is followed by C<temp>, a temporary overlay will be used.  On vfat or msdos formatted devices, --overlay-size-mb <size> must also be provided for a persistent overlay.  OverlayFS overlays are directories of the files that have changed on the read-only root filesystem.  With non-vfat-formatted devices, the OverlayFS can extend the available root filesystem space up to the capacity of the Live USB device.
-
-The --overlayfs option requires an initial boot image based on dracut version 045 or greater to use the OverlayFS feature.  Lacking this, the device boots with a temporary Device-mapper overlay.
-
-=item --overlay-size-mb <size>[,fstype[,blksz]]
-
-Specifies creation of a filesystem overlay of <size> mebibytes (integer values only).  [fstype] and [blksz] are relevant only for creating OverlayFS overlay filesystems on vfat-formatted primary devices.  An overlay makes persistent storage available to the live operating system, if permitted and installed on writable media.  The overlay holds a snapshot of changes to the root filesystem.
-
-B<Note well> that deletion of any original files in the read-only root filesystem does not recover any storage space on your LiveOS device.  Storage in the persistent F</LiveOS/overlay-<device_id>> file is allocated as needed.  If the overlay storage space is filled, the overlay will enter an 'Overflow' state where the root filesystem will continue to operate in a read-only mode.  There will not be an explicit warning or signal when this happens, but applications may begin to report errors due to the restriction.  If significant changes or updates to the root filesystem are to be made, carefully watch the fraction of space allocated in the overlay by issuing the C<dmsetup status> command at a command line of the running LiveOS image.  Some consumption of root filesystem and overlay space can be avoided by specifying a persistent home filesystem for user files, see --home-size-mb below.  The target storage device must have enough free space for the image and the overlay.  A maximum <size> of 4096 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
-
-=item --copy-overlay
-
-This option allows one to copy the persistent overlay from one live image to the new image.  Changes already made in the source image will be propagated to the new installation.
-
-=over 4
-
-B<WARNING:> User sensitive information such as password cookies and application or user data will be copied to the new image!  Scrub this information before using this option.
-
-=back
-
-=item --reset-overlay
-
-This option will reset the persistent overlay to an unallocated state.  This might be used if installing a new or refreshed image onto a device with an existing overlay, and avoids the writing of a large file on a vfat-formatted device.  This option also renames the overlay to match the current device filesystem label and UUID.
-
 =item --home-size-mb <size>[,fstype[,blksz]]
 
 Specifies creation of a home filesystem of <size> mebibytes (integer values only).  A persistent home directory will be stored in the F</LiveOS/home.img> filesystem image file.  This filesystem is encrypted by default and not compressed  (one may bypass encryption with the --unencrypted-home option).  When the home filesystem storage space is full, one will get out-of-space warnings from the operating system.  The target storage device must have enough free space for the image, any overlay, and the home filesystem.  Note that the --delete-home option must also be selected to replace an existing persistent home with a new, empty one.  A maximum <size> of 4096 MiB is permitted for vfat-formatted devices.  If there is not enough room on your device, you will be given information to help in adjusting your settings.
@@ -210,7 +214,7 @@ This option allows one to copy a persistent F<home.img> filesystem from the sour
 
 =over 4
 
-B<WARNING:> User-sensitive information, such as password cookies and user and application data, will be copied to the new image! Scrub this information before using this option.
+B<WARNING:>  User-sensitive information, such as password cookies and user and application data, will be copied to the new image! Scrub this information before using this option.
 
 =back
 

--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -213,7 +213,7 @@ class ImageCreator(object):
         """
         pass
 
-    def _stage_final_image(self):
+    def _stage_final_image(self, ops=[]):
         """Stage the final system image in _outdir.
 
         This is the hook where subclasses should place the image in _outdir

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -398,7 +398,10 @@ class LiveImageEditor(LiveImageCreator):
         directory for merging in base_on()."""
 
         self.ovltype = None
-        """Specifies the type of overlay ('dir', or fstype)."""
+        """Specifies the type of overlay ('dir', or 'temp')."""
+
+        self.ovl_fstype = None
+        """Specifies the type of filesystem in the overlay."""
 
         self.includes = []
         """A string of file or directory paths to copy to the .iso file in
@@ -574,7 +577,7 @@ class LiveImageEditor(LiveImageCreator):
         ops = ''
         f = ''  # variable & flag for iso-scan/filename booted host.
         self.ovl_size = 0
-        if self.src_type in ('live', 'OFS'):
+        if self.src_type == 'live':
             src = os.path.join('/run', 'initramfs', 'isoscandev')
                 # (^ Requires dracut verion 051 or greater.)
             if os.path.exists(src):
@@ -612,14 +615,15 @@ class LiveImageEditor(LiveImageCreator):
                     self._overlay = src[1][src[1].find(
                                     'upperdir=')+9:src[1].find(',workdir=')]
                     if not f and os.path.islink(self._overlay):
-                        self._overlay = os.path.dirname(
-                                            os.path.realpath(self._overlay))
+                        self.ovltype = 'dir'
+                        self._overlay = os.path.realpath(self._overlay)
                         self.overlayloop = findmnt('-no SOURCE', self._overlay)
                         if self.overlayloop:
+                            self.ovltype = 'OFS'
                             self.srcdir = os.path.join(self.srcmntdir,
                                        os.path.dirname(losetup('-nO BACK-FILE',
                                           self.overlayloop)).lstrip(os.sep))
-                    if not os.path.islink(self._overlay):
+                    elif not os.path.islink(self._overlay):
                         self.ovltype = 'tempdir'
                     self.imgloop = findmnt('-no SOURCE', base_mp)
             else:
@@ -631,7 +635,7 @@ class LiveImageEditor(LiveImageCreator):
                     self.ovltype = overlay = 'DM_linear'
             if not f:
                 self.liveossrc = None
-            if not f and self.ovltype not in ('DM_linear', 'tempdir'):
+            if not f and self.ovltype not in ('DM_linear', 'tempdir', 'dir'):
                 self._overlay = find_overlay(base_on)
                 if self._overlay:
                     if os.path.isdir(self._overlay):
@@ -656,7 +660,9 @@ class LiveImageEditor(LiveImageCreator):
             # need recovery.
             self.liveosmnt._LiveImageMount__create(ops='rw', dirmode=0o700)
             if isinstance(self.liveosmnt.livemount, OverlayFSMount):
-                self.src_type = 'embedded-OFS'
+                self.src_type = 'OFS'
+                if self.liveosmnt.cowloop:
+                    self.src_type = 'embedded-OFS'
                 # src_type dir with no overlay also passes here.
             if self.liveosmnt.ovltype in ('', 'temp'):
                 self._overlay = self.liveosmnt.cowloop.lofile
@@ -684,7 +690,7 @@ class LiveImageEditor(LiveImageCreator):
                     tgt = self.liveosmnt.homemnt.diskmount.disk.lofile
                 self._fsck_img(tgt, self.liveosmnt.homemnt.fstype)
             ops = 'ro'
-        if self.src_type not in ('live', 'OFS'):
+        if self.src_type != 'live':
             try:
                 # Read-only devices speed image copying.
                 self.liveosmnt.mount(ops=ops, dirmode=0o400)
@@ -710,7 +716,7 @@ class LiveImageEditor(LiveImageCreator):
             self.srcmntdir = findmnt('-no TARGET -T', losm.srcdir)
             self.imgloop = losm.imgloop.device
 
-        if self.src_type in ('OFS', 'live'):
+        if self.src_type == 'live':
             if not self.imgloop:
                 self.imgloop = os.path.realpath('/dev/live-base')
             for i in ('0', '1'):
@@ -760,9 +766,13 @@ class LiveImageEditor(LiveImageCreator):
             self._LoopImageCreator__fstype = self.root_fstype
         if not os.path.exists(self.liveosdir):
             raise CreatorError("No LiveOS directory on %s" % base_on)
-        self.bootfolder = os.path.join(self.liveosmnt.srcdir, 'syslinux')
+        self.bootfolder = os.path.join(self.srcdir, 'syslinux')
+        self.imagesdir = os.path.join(self.srcdir, 'images')
+        if not os.path.exists(self.imagesdir):
+            self.imagesdir = os.path.join(self.srcmntdir, 'images')
+            self.bootfolder = os.path.join(self.srcmntdir, 'syslinux')
         if not os.path.exists(self.bootfolder):
-            self.bootfolder = os.path.join(self.srcmntdir, 'isolinux')
+            self.bootfolder = os.path.join(self.srcdir, 'isolinux')
 
         self.home_img = os.path.join(self.liveosdir, 'home.img')
         self.isohome_img = os.path.join(self._LiveImageCreatorBase__isodir,
@@ -865,6 +875,7 @@ class LiveImageEditor(LiveImageCreator):
         if self.is_squashed:
             squash_img = losetup('-nO BACK-FILE', self.squashloop)
             img = squash_img
+            required = int(get_blockdev_size(self.squashloop))
         else:
             self.compress_args = 'gzip'
         # 'self.compress_args = None' will force reading it from base_on.
@@ -895,10 +906,10 @@ class LiveImageEditor(LiveImageCreator):
         if findmnt('-no FSTYPE -T', fsroot) == 'overlay':
             rootfs_used = int(rcall(['df', '-B1', '--output=used', fsroot],
                                     raise_err=False)[0].split()[-1])
-            required = self._LoopImageCreator__image_size
         else:
             rootfs_used = int(rcall(du_args, fsroot,
                                     raise_err=False)[0].split()[-2])
+        if rootfs_used > required:
             required = rootfs_used
 
         self.home_used = int(rcall(du_args, os.path.join(fsroot, 'home'),
@@ -931,7 +942,7 @@ class LiveImageEditor(LiveImageCreator):
                 self.home_size_mb = self.home_img_size + self.home_size_mb
             if self.home_size_mb < self.home_used and self.home_size_mb != 0:
                 self.home_size_mb = self.home_used + self.home_used // 8
-            if self.src_type in ('live', 'OFS') and self.home_size_mb > 0:
+            if self.src_type == 'live' and self.home_size_mb > 0:
                 # space for staging new home.img filesystem
                 required += self.home_size_mb
             homesize = self.home_size_mb
@@ -1036,7 +1047,7 @@ class LiveImageEditor(LiveImageCreator):
                       ' extra bytes set to be copied from the sources.')
                      ).format(tobe_copied),)
         print(''.join((' ', self.fmt,
-                    ' bytes are in the LiveOS filesystem in {1:s}.\n')).format(
+                   ' bytes used in the LiveOS filesystem in {1:s}.\n')).format(
                        rootfs_used, self.src))
         if homesize > 0:
             print(''.join(('(', self.fmt,
@@ -1111,7 +1122,7 @@ class LiveImageEditor(LiveImageCreator):
 
         if os.path.exists(self.home_img):
             ops = []
-            if self.src_type in ('live', 'OFS'):
+            if self.src_type == 'live':
                 self.newhome_img = tempfile.mkstemp(suffix='.img', prefix='h-',
                                    dir=self._LoopImageCreator__imagedir)[1]
                 self.newhomemnt.disk.lofile = self.newhome_img
@@ -1167,7 +1178,7 @@ class LiveImageEditor(LiveImageCreator):
         shutil.copytree(src, dst, symlinks=True,
                         ignore=shutil.ignore_patterns(*ignore_list))
 
-        for src in (self.bootfolder, os.path.join(self.srcdir, 'images')):
+        for src in (self.bootfolder, self.imagesdir):
             copypaths([src], isodir)
 
         for src in ('LICENSE', 'Fedora-Legal-README.txt', 'EFI'):
@@ -1209,7 +1220,7 @@ class LiveImageEditor(LiveImageCreator):
         elif dm_table_list[2] == 'linear':
             self.overlayloop = None
         self.osminloop = None
-        if self.src_type in ('live', 'OFS'):
+        if self.src_type == 'live':
             dm_table_list = get_dm_table('live-osimg-min').split()
             if dm_table_list:
                 self.osminloop = '/dev/loop' + dm_table_list[4].split(':')[1]
@@ -1295,7 +1306,7 @@ class LiveImageEditor(LiveImageCreator):
         homedir = os.path.join(self._ImageCreator_instroot, 'home')
         if self.home_size_mb and self.home_size_mb >= 0:
             if self.home_size_mb == 0:
-                if self.src_type in ('live', 'OFS'):
+                if self.src_type == 'live':
                     homeroot = '/home'
                 else:
                     if self.liveosmnt.EncHome:
@@ -1323,7 +1334,7 @@ class LiveImageEditor(LiveImageCreator):
                 os.rmdir(p)
                 if not os.listdir(os.path.join(homedir, 'lost+found')):
                     os.rmdir(os.path.join(homedir, 'lost+found'))
-                if self.src_type not in ('live', 'OFS'):
+                if self.src_type != 'live':
                     tmphome_mnt.cleanup()
                 os.remove(self.home_img)
                 if liveosmnt:
@@ -1345,8 +1356,7 @@ class LiveImageEditor(LiveImageCreator):
                     print('Copying home.img to source device.')
                     shutil.copy2(self.newhome_img, self.home_img)
                 self.newhomemnt.mountdir = homedir
-            elif ((self.src_type in ('live', 'OFS')
-                 or self.EncHomeReq is not None)
+            elif ((self.src_type == 'live' or self.EncHomeReq is not None)
                  and hasattr(self, 'newhome_img')):
                 os.remove(self.home_img)
                 print('Copying home.img to source device.')
@@ -1374,7 +1384,7 @@ class LiveImageEditor(LiveImageCreator):
                                                            self.isohome_img,
                                                            self.home_img_size),
                                             homedir)
-            if self.src_type in ('live', 'OFS'):
+            if self.src_type == 'live':
                 self.newhomemnt = BindChrootMount('/home', self._instroot,
                                                   None)
             elif self.liveosmnt.homemnt:
@@ -1451,31 +1461,31 @@ class LiveImageEditor(LiveImageCreator):
         if not os.path.exists(self.initrd):
             self.initrd = os.path.join(isodir, 'initrd0.img')
         img = os.path.basename(self.initrd)
-        if msg == 'update' and self.kernels != self.kernels0:
-            print('Updating kernel & initial ram filesystem images...')
+        if msg == 'update':
             cmd = ['sort', '-rV']
             a, err, rc = rcall(cmd, '\n'.join(self.kernels))
             a = a.split('\n')[0]
-            rc = os.path.join(self._instroot, 'boot',
-                                               'initramfs-' + a + '.img')
-            d = os.path.join(self._instroot, 'usr', 'lib', 'modules', a)
-            cmd = ['dracut', rc, '--kmoddir', d, '--kver', a, '--no-hostonly',
-                   '--add', 'dmsquash-live', '--force']
-            if self.src_fstype == 'f2fs':
-                cmd += ['--add-drivers', 'f2fs']
-            print('using this command:\n%s' % cmd)
-            call(cmd)
-            a = os.path.join(d, vm)
-            imagedirs = [os.path.join(self.srcdir, 'syslinux'),
-                os.path.join(self.srcdir, 'images', 'pxeboot'),
-                os.path.join(self._LiveImageCreatorBase__isodir, 'isolinux'),
-                os.path.join(self._LiveImageCreatorBase__isodir, 'images',
-                             'pxeboot')]
-            if not os.access(imagedirs[1], os.W_OK):
-                del imagedirs[0:2]
-            [shutil.copy2(rc, os.path.join(d, img)) for d in imagedirs]
-            [shutil.copy2(a, os.path.join(d, vm)) for d in imagedirs]
-        if msg == 'update':
+            if self.kernels != self.kernels0 or self.initrd_kernel != a:
+                print('Updating kernel & initial ram filesystem images...')
+                rc = os.path.join(self._instroot, 'boot',
+                                                   'initramfs-' + a + '.img')
+                d = os.path.join(self._instroot, 'usr', 'lib', 'modules', a)
+                cmd = ['dracut', rc, '--kmoddir', d, '--kver', a,
+                       '--no-hostonly', '--add', 'dmsquash-live', '--force']
+                if self.src_fstype == 'f2fs':
+                    cmd += ['--add-drivers', 'f2fs']
+                print('using this command:\n%s' % cmd)
+                call(cmd)
+                a = os.path.join(d, vm)
+                imagedirs = [self.bootfolder,
+                  os.path.join(self.imagesdir, 'pxeboot'),
+                  os.path.join(self._LiveImageCreatorBase__isodir, 'isolinux'),
+                  os.path.join(self._LiveImageCreatorBase__isodir, 'images',
+                               'pxeboot')]
+                if not os.access(imagedirs[1], os.W_OK):
+                    del imagedirs[0:2]
+                [shutil.copy2(rc, os.path.join(d, img)) for d in imagedirs]
+                [shutil.copy2(a, os.path.join(d, vm)) for d in imagedirs]
             return
 
         print('Checking kernel versions in %s...' % msg)
@@ -1874,7 +1884,7 @@ s/\s+$//}}'''
             # No overlay to look below.
             return
 
-        if self.src_type in ('live', 'OFS'):
+        if self.src_type == 'live':
             imgloop = LoopbackDisk(self.imgloop, 0, 'ro')
         else:
             imgloop = self.liveosmnt.imgloop
@@ -1987,8 +1997,7 @@ s/\s+$//}}'''
         """
         (Hijacked either the _LiveImageCreatorBase__implant_md5sum or
         _LiveImageCreatorBase__create_isobase method) to insert code to refresh
-        a running or livemounted image's rootfs_img and overlay files (just
-        before the staged files are deleted).
+        a running or livemounted image's rootfs_img and overlay files.
         """
         if not self.refresh_only:
             # Implant an isomd5sum.
@@ -2119,12 +2128,12 @@ s/\s+$//}}'''
         else:
             overlay = args.overlay
 
+        ovlmntdir = self.srcmntdir
         if self.src_type == 'live' and not (self.flatten_squashfs or
                                             self.overlay_size_mb or
                                             self.ovltype == 'DM_linear'):
             self.overlay_size_mb = self.ovl_size
             self.ovl_fstype = self.ovltype
-            ovlmntdir = self.srcmntdir
             if self.liveosmnt and self.liveosmnt.ovlmnt:
                 self.liveosmnt.ovlmnt.mount()
                 ovlmntdir = self.liveosmnt.ovlmntdir
@@ -2138,15 +2147,17 @@ s/\s+$//}}'''
             'DM_snapshot_cow')) or (self.overlay_size_mb and
             self.ovltype in ('', 'DM_snapshot_cow', 'DM_linear') and
             self.ovl_fstype not in ('', 'temp','DM_snapshot_cow')):
+            # Represents need for a new OverlayFSMount.
+            self.ovltype = 'dir'
             if not self.overlay_size_mb:
                 self.overlay_size_mb = self.ovl_size
-                self.ovl_fstype = 'dir'
-                ovlmntdir = self.srcmntdir
+#                self.ovl_fstype = 'dir'
                 if self.liveosmnt and self.liveosmnt.ovlmnt:
                     self.liveosmnt.ovlmnt.mount()
                     ovlmntdir = self.liveosmnt.ovlmntdir
-                if findmnt('-no FSTYPE -T', ovlmntdir) == 'vfat':
-                    self.ovl_fstype = 'ext4'
+            if self.src_fstype == 'vfat' and not self.ovl_fstype:
+                self.ovltype = 'embedded-OFS'
+                self.ovl_fstype = 'ext4'
                 self.ovl_blksz = 4096
 
             cmd[3:] = [
@@ -2165,10 +2176,41 @@ s/\s+$//}}'''
             cmd[3:] = [r'/{0}/ s/ rd\.live\.overlay\.overlayfs//g'.format(dn),
                        EFI_config]
             call(cmd)
+
+        self.liveosmnt = self.new_liveos_mount(self.src, args.rootfsimg,
+                                               overlay, self.mntdir)
+        self.liveosmnt._LiveImageMount__create(ops='rw', dirmode=0o700)
+
+        if self.overlay_size_mb:
+            self.liveosmnt.overlay = None
+
+            overlay = self.liveosmnt.make_overlay(self.overlay_size_mb,
+                                                  self.ovl_size,
+                                                  self.ovltype,
+                                                  self.ovl_fstype,
+                                                  self.ovl_blksz)
+            self.liveosmnt.cleanup()
+            self.liveosmnt.overlay = overlay[0]
+            cmd[3:] = [r'''/^\s*append/ {{
+            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/}}
+            '''.format(overlay[1]), cfgf]
+            call(cmd)
+            cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
+            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={1}/}}
+            '''.format(dn, overlay[1]), EFI_config]
+            call(cmd)
+        elif self.ovltype != 'DM_linear':
+            self.liveosmnt.reset_overlay()
+
+        cmd[3:] = [r'''/^\s*append|linuxefi/I {{
+        :w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw
+        s/\>\s\s+/ /g
+        s/\s+$//}}''', cfgf, EFI_config]
+        call(cmd)
+
         shutil.copy2(EFI_config, c)
 
         self.src_partition = findmnt('-no SOURCE', self.srcmntdir)
-
         c = lsblk('-no NAME,PKNAME', self.src_partition).split()
         d = '/dev/' + c[1]
         p = c[0][len(c[1]):]
@@ -2188,10 +2230,10 @@ s/\s+$//}}'''
                           dirmode=0o700)
             e.mount()
             d = e.mountdir
+            EFI_config_p = os.path.join(d, EFI_dir, 'grub.cfg')
             if os.access(d, os.W_OK):
                 for f in ('BOOT.conf.prev', 'grub.cfg.prev'):
-                    shutil.copy2(EFI_config + '.prev',
-                                 os.path.join(d, EFI_dir, f))
+                    shutil.copy2(EFI_config_p, os.path.join(d, EFI_dir, f))
                 for f in ('BOOT.conf', 'grub.cfg'):
                     shutil.copy2(EFI_config, os.path.join(d, EFI_dir, f))
                 if p == p3[0]:
@@ -2203,39 +2245,14 @@ s/\s+$//}}'''
             e.cleanup()
             return [p, e]
 
-        for p in [[p2, 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'],
-                  [p3, '48465300-0000-11aa-aa11-00306543ecac']]:
+        for p in [[p2, 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b', '0xef'],
+                  [p3, '48465300-0000-11aa-aa11-00306543ecac', '0xaf']]:
             c = lsblk('-no NAME,PARTTYPE', p[0][0]).split()
-            if c and c[1] == p[1]:
+            if c and (c[1] == p[1] or c[1] == p[2]):
                 p[0] += cp_cfg(p[0][0])
             else:
                 p[0][0] = ''
                 p[0] += [False]
-
-        self.liveosmnt = self.new_liveos_mount(self.src, args.rootfsimg,
-                                               overlay, self.mntdir)
-        self.liveosmnt._LiveImageMount__create(ops='rw', dirmode=0o700)
-
-        if self.overlay_size_mb:
-            self.liveosmnt.overlay = None
-            overlay = self.liveosmnt.make_overlay(self.overlay_size_mb,
-                                                  self.ovl_size,
-                                                  self.ovl_fstype,
-                                                  self.ovl_blksz)
-            self.liveosmnt.cleanup()
-            self.liveosmnt.overlay = overlay[0]
-            cmd[3:] = [r'''/^\s*append/ {{
-            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/
-            :w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw}}
-            '''.format(overlay[1]), cfgf]
-            call(cmd)
-            cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
-            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={1}/
-            :w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw}}
-            '''.format(dn, overlay[1]), EFI_config]
-            call(cmd)
-        elif self.ovltype != 'DM_linear':
-            self.liveosmnt.reset_overlay()
 
         cmd = ['sed', '-n', '-r']
         sedscript = r'''/^\s*label\s+linux/I {n;n;n
@@ -2243,8 +2260,9 @@ s/\s+$//}}'''
         cmd.extend([sedscript, cfgf])
         kcmdline, err, rc = rcall(cmd)
         kcmdline = kcmdline.rstrip()
-        self.kernel_release = get_file_info(self.kernel)[7]
 
+        # self.kernel_release below is from last invocation of
+        #  check_kernel_versions(editor.bootfolder, 'source image')
         if self.src_fstype == 'f2fs' and p2[0]:
             d, err, rc = rcall(['dump.f2fs', self.src_partition])
             if 'extra_attr' in d:
@@ -2480,6 +2498,13 @@ def main():
             print("\nNOTICE:  An overlay is unsuitable for '%s'.\n" % 
                   args.liveos, file=sys.stderr) 
             return 1
+    if src_fstype == 'f2fs' and not args.skip_refresh and not os.path.exists(
+        os.path.join('/', 'usr', 'sbin', 'fsck.f2fs')):
+        print('''
+        \rNOTICE:  The host system must have the 'f2fs-tools' package
+         installed in order to complete this editliveos session.\n
+         Run 'sudo dnf install f2fs-tools'.\n''')
+        return 1
     if args.name:
         name = args.name
         if any(n in os.sep for n in name):
@@ -2494,7 +2519,7 @@ def main():
         output = args.output
     elif src_type == 'iso':
         output = os.path.dirname(os.path.normpath(args.liveos))
-    elif src_type in ('live', 'OFS', 'dir', 'blk'):
+    elif src_type in ('live', 'dir', 'blk'):
         output = args.tmpdir
 
     editor = LiveImageEditor(name, docleanup=not args.nocleanup)
@@ -2603,8 +2628,8 @@ def main():
         isodir = editor.bootfolder
         editor.kernels = None
         editor.check_kernel_versions(editor.bootfolder, 'current image')
-        editor.check_kernel_versions(os.path.join(editor.srcdir, 'images',
-            'pxeboot'), 'current .iso')
+        editor.check_kernel_versions(os.path.join(editor.imagesdir, 'pxeboot'),
+            'current .iso')
         editor.kernel_version0 = editor.kernel_release
         editor.initrd_kernel0 = editor.initrd_kernel
         editor.kernels0 = editor.kernels
@@ -2637,8 +2662,8 @@ def main():
             editor.check_kernel_versions(isodir, 'new install image')
         if ((not editor.src_type == 'iso' or editor.skip_refresh) and
             not hasattr(editor, 'isosrcmnt')):
-            editor.check_kernel_versions(os.path.join(editor.srcdir,
-                'images', 'pxeboot'), 'source PXE')
+            editor.check_kernel_versions(os.path.join(editor.imagesdir,
+                'pxeboot'), 'source PXE')
             editor.check_kernel_versions(editor.bootfolder, 'source image')
         if editor.liveosmnt:
             if editor.refresh_only:


### PR DESCRIPTION
…sing.

Avoid hfsplus-tools use and macboot.img processing with the new --nomac
option.
 - Include ESP update processing on MBR partitioned disks.
 - Preserve previous working copy of grub.cfg in ESP upon multi image
   install (useful for hand customized configurations).
 - Tweak required resource estimates.
 - Include missing ops parameter in _stage_final_image() definition.
 - Add xfs_admin label code to LiveImageMount.make_overlay().
 - Remove some obsolete code.
 - Update documentation.