### PR TITLE
fs.py:  Avoid bind mounting an existing file target.

### DIFF
--- a/imgcreate/fs.py
+++ b/imgcreate/fs.py
@@ -1028,6 +1028,8 @@ class BindChrootMount():
             makedirs(os.path.dirname(os.path.realpath(self.dest)))
             if not os.path.exists(self.dest):
                 open(self.dest, 'a').close()
+            else:
+                return
         args = ['mount', '--bind', self.src, self.dest]
         rc = call(args)
         if rc != 0:


### PR DESCRIPTION
Fix issue #233 with editliveos unnecessarily bind mounting a file
under /run leading to an unmount failure.

`/etc/resolv.conf` is not present in earlier versions but the Fedora 36 image includes it as a link to `../run/systemd/resolve/stub-resolv.conf`.