### PR TITLE
Optionally enforce GPG signatures on installed RPMs

### DIFF
--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -30,6 +30,7 @@ from dnf.exceptions import Error as DnfBaseError
 
 import imgcreate
 from imgcreate.errors import KickstartError
+from imgcreate.util import gpg_keys_from_linesiter
 
 class Usage(Exception):
     def __init__(self, msg = None, no_error = False):
@@ -78,6 +79,13 @@ def parse_options(args):
     imgopt.add_option("", "--releasever", type="string", dest="releasever",
                       default=None,
                       help="Value to substitute for $releasever in kickstart repo urls")
+    imgopt.add_option("", "--repo-keys", type="string", dest="repo_keys",
+                      default=None,
+                      help="If present, require that all installed RPMs be signed with "
+                           "the public key(s) listed in this file. The file must "
+                           "contain one or more GPG public keys in ascii-armor format. "
+                           "Use the GPG signing keys from your distro's website. If "
+                           "omitted, no signature-checking is performed.")
     parser.add_option_group(imgopt)
 
     # options related to the config of your system
@@ -201,6 +209,16 @@ def main():
         print("Kickstart (%s) must have at least one repository." % (options.kscfg), file=sys.stderr)
         return 1
 
+    repo_keys = []
+    if options.repo_keys:
+        repo_keys = read_gpg_keys(options.repo_keys)
+        if not repo_keys:
+            print("GPG keyfile (%s) must contain at least one GPG "
+                  "public key in ascii armor format." %
+                  (options.repo_keys), file=sys.stderr)
+            return 1
+        logging.info("RPM signatures will be checked against %u GPG keys", len(repo_keys))
+
     try:
         if options.image_type == 'livecd':
             creator = imgcreate.LiveImageCreator(ks, name,
@@ -231,7 +249,7 @@ def main():
 
     try:
         creator.mount(options.base_on, options.cachedir)
-        creator.install()
+        creator.install(repo_keys=repo_keys)
         if (options.flat_squashfs and
           'rd.live.overlay.overlayfs' not in ks.handler.bootloader.appendLine):
             ks.handler.bootloader.appendLine += 'rd.live.overlay.overlayfs'
@@ -259,6 +277,11 @@ def do_nss_libs_hack():
     hack = [ hack, forgettable._dlopen('libnss_systemd.so.2') ]
     del forgettable
     return hack
+
+def read_gpg_keys(gpg_keyfile):
+    with open(gpg_keyfile, "r") as infile:
+        lines = infile.read()
+    return list(gpg_keys_from_linesiter(lines.splitlines()))
 
 if __name__ == "__main__":
     hack = do_nss_libs_hack()


### PR DESCRIPTION
This PR adds the optional CLI argument `--repo-keys=FILE` for specifying GPG public keys. GPG keys listed in this file will be used to verify all RPMs installed during image generation. This protects the generated images against potential supply-chain attacks from untrustworthy mirrors. User action is required to enable this protection.

Closes #225.

I see plenty of topics for discussion here, and I am certainly open to alternative implementations.

## Known shortcomings

* The kickstart file format does not permit specifying a public key or key ID. This is blocked on pykickstart/pykickstart#32 or similar changes. We require some external mechanism to specify keys. In this PR, we specify them manually in another file.

* User intervention is required to enable signature-checking. The user must manage the keys themselves. This is less than ideal.

  * Automatic key retrieval (i.e., via keyserver or DNS) is not supported. This is probably okay. We should not rely on users being able to retrieve keys at build time.

  * A better approach to key management may be to add [`distribution-gpg-keys`](https://mageia.pkgs.org/8/mageia-core-release-x86_64/distribution-gpg-keys-1.48-1.mga8.noarch.rpm.html) as an optional dependency. If present, we could ingest all of these keys by default and require user intervention to *disable* the checks. The user could add other keys as necessary.

* We parse GPG keys and convert them to binary ourselves, in python. There may be a cleaner way to do this.

## Implementation notes

It is not immediately clear to me how one is supposed to insert a GPG key via the dnf API. Fortunately,

* rpm exposes [`rpmcliImportPubkey()`](http://ftp.rpm.org/api/4.4.2.2/group__rpmcli.html#g6a17ba25516688beb36616c897241f89) for this purpose

* recent rpm>=[4.14.2](https://rpm.org/wiki/Releases/4.14.2) includes the `%_pkgverify_level` macro for enforcing signature checks

We use these rpm APIs directly for signature-checking.

## Recommended tests:

- [ ] `--repo-keys /usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia` **succeeds**. If you use the correct keys for your distro, the image should build. This particular example requires `distribution-gpg-keys`.

- [ ] `--repo-keys some/wrong/key.asc` **fails**. Use any personal public key you want. RPM signature verification should fail and abort the build.

- [ ] `--repo-keys /dev/null` **fails**. It is an error to specify a keys file that contains zero keys.

- [ ] Ensure that images continue build normally without the new `--repo-keys`.