### PR TITLE
imgcreate/kickstart.py: correct setfiles relabeling

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -799,7 +799,11 @@ class ImageCreator(object):
         self._create_bootconfig()
 
         self._run_post_scripts()
-        kickstart.SelinuxConfig(self._instroot).apply(ksh.selinux)
+        try:
+            self._undo_bindmounts()
+            kickstart.SelinuxConfig(self._instroot).apply(ksh.selinux)
+        finally:
+            self._do_bindmounts()
 
     def launch_shell(self):
         """Launch a shell in the install root.


### PR DESCRIPTION
This patch corrects several issues with the setfiles SELinux relabel command. The issues become apparent when the host and guest policies differ. This patch is required to build a (functioning) selinux-enforcing Alma 8 image using a Fedora 35 host. There are probably many other host/guest combinations which are also affected.

### setfiles uses kernel policies by default

By default, setfiles consults the kernel's loaded sepolicy if there is one. You can demonstrate this on a selinux-enabled system with strace:

    sudo strace -etrace=file \
      setfiles -Fvn \
      /etc/selinux/targeted/contexts/files/file_contexts \
      /dev/null

This does a dry-run relabel of /dev/null. The -n option prevents any changes from being made. Observe that strace reports

> openat(AT_FDCWD, "/sys/fs/selinux/context", O_RDWR|O_CLOEXEC) = 4

which is an indication that setfiles is consulting the kernel policy in some way.

This will cause problems if the guest has a different selinux-policy-targeted version than the host. A mismatch can result in invalid labels that will go on to cause SELinux malfunctions on the guest.

We can avoid this issue by specifying a binary policy file directly with `-c`. See again,

    sudo strace -etrace=file \
      setfiles -Fvn \
      -c /etc/selinux/targeted/policy/policy.* \
      /etc/selinux/targeted/contexts/files/file_contexts \
      /dev/null

This does not open /sys/fs/selinux/context and should read policy only from the given -c file.

### setfiles should use guest policy, not host policy

Previous versions of imgcreate found the path to file_contexts by consulting the loaded policy on the *host*. This can also be wrong: the guest might have a different policy file name. Instead of relying on the host and guest to have matching policies, we read this information from the guest's /etc/selinux/config file.

### relabel all parts of the context

Use `setfiles -F` to also relabel the user/role/range context fields if needed.

### don't relabel host files

We execute the relabel without bind mounts. This prevents the relabel from accidentally crossing into the host filesystem—which we do not want—and ensures that `/var/cache/dnf` receives the right label.

## Recommended Testing

Use Fedora 35 to build Alma 8.0 with selinux enabled. You can use a kickstart file like the one on
[cbs228/livecd-tools/setfiles_fix_with_alma_ks](https://github.com/cbs228/livecd-tools/blob/setfiles_fix_with_alma_ks/config/livecd-alma8-minimal.ks).

```bash
sudo livecd-creator \
    --config=config/livecd-alma8-minimal.ks \
    --cache=/var/tmp/livecache \
    --flat-squashfs
```

After the build completes, mount the root filesystem from the ISO and run:

```bash
sudo chroot /the/mountpoint/for/rootfs \
    /usr/sbin/setfiles -n -v -F \
    -e /proc -e /sys -e /dev \
    -c /etc/selinux/targeted/policy/policy.31 \
    /etc/selinux/targeted/contexts/files/file_contexts /
```

(You may need to adjust `.31` to be correct for the policy version.)

Without this patch, there are *lots* of incorrect labels reported as "`Would relabel`…". With this patch, there are none.

## Note

Although this patch improves compatibility for differing host and guest policies, host policy may still prevent unknown or conflicting labels from being assigned. This example works for me on stock a Fedora 35 system in Enforcing mode. If you receive SELinux denials, you will need to either modify your host's policy or temporarily use permissive mode.
