### PR TITLE
imgcreate/creator.py: fix SELinux unmount order

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -800,6 +800,7 @@ class ImageCreator(object):
 
         self._run_post_scripts()
         try:
+            self.__destroy_selinuxfs()
             self._undo_bindmounts()
             kickstart.SelinuxConfig(self._instroot).apply(ksh.selinux)
         finally:


### PR DESCRIPTION
Fix a bug introduced by my #236.

In 67081a3657, bind mounts are unmounted before the filesystem is relabeled with `setfiles`. The function which performs the unmount executes

    umount /sys/fs/selinux

without first executing

    umount /sys/fs/selinux/load

This can—but may not always—lead to a dreaded "*leaked a reference to the filesystem*" build error.

Fix by ensuring `/sys/fs/selinux/load` is unmounted first, just like [`ImageCreator.unmount()`](https://github.com/livecd-tools/livecd-tools/blob/867b9e7c477c5894586c55af7031da489e6ba6ff/imgcreate/creator.py#L583) does. We do not re-mount it afterwards because we shouldn't need to do anything more with SELinux after the relabel completes.