### PR TITLE
Optionally obtain repository config from .repo file instead of kickstart

### DIFF
--- a/README
+++ b/README
@@ -169,7 +169,38 @@ Multiple images may be loaded onto a single USB stick.
 
 See livecd-iso-to-disk --help for more options and instructions.
 
-6. MOUNTING LIVE IMAGES 
+6. SECURE IMAGE GENERATION
+
+Due to limitations in kickstart, the default invocation of livecd-creator
+cannot verify RPM package signatures. Package signatures are an essential
+security function which protects RPMs against tampering during storage or
+transfer.
+
+If possible, you should enable signature checks with the --repo option:
+
+  livecd-creator \
+    --config=/usr/share/doc/livecd-tools/livecd-fedora-minimal.ks \
+    --repo=/etc/yum.repos.d
+
+--repo configures RPM sources using DNF ".repo" configuration files instead of
+kickstart. If you are building a different distro than your host system, be sure
+to use configuration files for that distro.
+
+Your --repo file or directory can use any configuration options available to
+DNF. The following options must be set in order to verify signatures:
+
+  gpgcheck=1
+
+  gpgkey=path/to/key.asc
+         file:///url/to/another/key.asc
+
+In this mode, the %repo directive(s) in the kickstart file, if any,
+are ignored.
+
+Additionally, use --pkgverify-level=all to enforce valid, trusted
+signatures on all packages installed.
+
+7. MOUNTING LIVE IMAGES
 
 A live CD .iso file or an installed live USB device may be mounted with the
 liveimage-mount script to peer into the live OS filesystem, or even edit it on

--- a/docs/livecd-creator.pod
+++ b/docs/livecd-creator.pod
@@ -48,6 +48,11 @@ Title used by F<syslinux.cfg> file.
 
 Product name used in F<syslinux.cfg> boot stanzas and countdown.
 
+=item --repo=PATH
+
+Configure RPM repositories from the given file or directory of L<dnf.conf(5)>
+C<.repo> files. C<%repo> directives in the kickstart file will be ignored.
+
 =item  -p, --plugins
 
 Use DNF plugins during image creation.
@@ -67,6 +72,25 @@ Multiple arguments should be specified in one string, i.e., C<--compression-type
 =item --releasever=VER
 
 Set the value to substitute for $releasever in kickstart repo urls.
+
+=item --pkgverify-level=LEVEL
+
+Sets GPG signature and package digest options for RPM.
+See "C<%_pkgverify_level>" in F</usr/lib/rpm/macros>.
+
+=over 1
+
+=item C<all> require valid digest(s) and signature(s)
+
+=item C<signature> require valid signature(s)
+
+=item C<digest> require valid digest(s)
+
+=item C<none> traditional rpm behavior, nothing required
+
+=back
+
+GPG signature verification requires the use of C<--repo>.
 
 =back
 
@@ -144,6 +168,37 @@ repo --name=fedora --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo
 Note that in a chroot environment (like koji) the rpmdb is not available,
 so either don't use $releasever in that case, or pass --releasever=VER.
 
+=head1 SECURE IMAGE GENERATION
+
+Due to limitations in kickstart, the default invocation of livecd-creator
+cannot verify RPM package signatures. Package signatures are an essential
+security function which protects RPMs against tampering during storage or
+transfer.
+
+If possible, you should enable signature checks with the C<--repo> option:
+
+  livecd-creator \
+    --config=/usr/share/doc/livecd-tools/livecd-fedora-minimal.ks \
+    --repo=/etc/yum.repos.d
+
+--repo configures RPM sources using L<dnf.conf(5)> configuration files
+instead of kickstart. If you are building a different distro than your
+host system, be sure to use configuration files for that distro.
+
+Your --repo file or directory can use any configuration options available to
+DNF. The following options must be set in order to verify signatures:
+
+  gpgcheck=1
+
+  gpgkey=path/to/key.asc
+         file:///url/to/another/key.asc
+
+In this mode, the C<%repo> directive(s) in the kickstart file, if any,
+are ignored.
+
+Additionally, use C<--pkgverify-level=all> to enforce valid, trusted
+signatures on all packages installed.
+
 =head1 CONTRIBUTORS
 
 David Zeuthen, Jeremy Katz, Douglas McClendon and a team of many other contributors. See the AUTHORS file in the source distribution for the complete list of credits. 
@@ -158,6 +213,6 @@ Copyright (C) Fedora Project 2008,2009,2020, and various contributors. This is f
 
 =head1 SEE ALSO
 
-C<livecd-iso-to-disk(8)>, project website L<http://fedoraproject.org/wiki/FedoraLiveCD>
+L<livecd-iso-to-disk(8)>, L<dnf.conf(5)>, project website L<http://fedoraproject.org/wiki/FedoraLiveCD>
 
 =cut

--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -676,7 +676,7 @@ class ImageCreator(object):
                     raise CreatorError("Failed to find package '%s' : %s" %
                                        (pkg_name, e))
 
-    def install(self, repo_urls = {}, repo = None):
+    def install(self, repo_urls={}, repo=None, pkgverify_level=None):
         """Install packages into the install root.
 
         This function installs the packages listed in the supplied kickstart
@@ -694,6 +694,12 @@ class ImageCreator(object):
                      this file or directory. If this argument is provided,
                      repos defined in the kickstart are ignored. This is useful
                      for setting advanced dnf options like gpg keys.
+
+        pkgverify_level  -- sets RPM's %_pkgverify_level macro for enforcing
+                            GPG signature and/or digest verification. Set to
+                            "all" to enforce trusted GPG signatures for all
+                            installed packages. Omit to use RPM's default
+                            setting. See /usr/lib/rpm/macros.
         """
         dnf_conf = self._mktemp(prefix = "dnf.conf-")
 
@@ -731,7 +737,8 @@ class ImageCreator(object):
 
         try:
             self.__apply_selections(dbo)
-
+            if pkgverify_level:
+                dbo.setPkgVerifyLevel(pkgverify_level)
             dbo.runInstall()
         except (dnf.exceptions.DownloadError, dnf.exceptions.RepoError) as e:
             raise CreatorError("Unable to download from repo : %s" % (e,))

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -80,6 +80,15 @@ def parse_options(args):
                       help="Configure RPM repositories from a .repo file or directory "
                            "instead of kickstart. See /etc/yum.repos.d/ for example "
                            "configuration files.")
+    imgopt.add_option("", "--pkgverify-level",
+                      type="choice",
+                      choices=["all", "signature", "digest", "none"],
+                      dest="pkgverify_level",
+                      default=None,
+                      help="Configures RPM package verification. Use \"all\" to enforce "
+                           "trusted GPG signatures and strong digests for every "
+                           "package. Only affects packages installed during the "
+                           "%install step.")
     imgopt.add_option("", "--releasever", type="string", dest="releasever",
                       default=None,
                       help="Value to substitute for $releasever in kickstart repo urls")
@@ -210,6 +219,12 @@ def main():
         print("Ignoring kickstart (%s) repo definitions in favor of \"%s\"" %
               (options.kscfg, options.repo), file=sys.stderr)
 
+    if options.pkgverify_level in ("all", "signature") and not options.repo:
+        print(f"Option --pkgverify-level={options.pkgverify_level} requires "
+              "the use of --repo=PATH for repo configuration",
+              file=sys.stderr)
+        return 1
+
     try:
         if options.image_type == 'livecd':
             creator = imgcreate.LiveImageCreator(ks, name,
@@ -240,7 +255,7 @@ def main():
 
     try:
         creator.mount(options.base_on, options.cachedir)
-        creator.install({}, options.repo)
+        creator.install({}, options.repo, options.pkgverify_level)
         if (options.flat_squashfs and
           'rd.live.overlay.overlayfs' not in ks.handler.bootloader.appendLine):
             ks.handler.bootloader.appendLine += 'rd.live.overlay.overlayfs'

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -75,6 +75,11 @@ def parse_options(args):
                            "Multiple arguments should be specified in "
                            'one string, i.e., --compression-type "type arg1 arg2 ...".',
                       default="xz")
+    imgopt.add_option("", "--repo", type="string", dest="repo",
+                      default=None,
+                      help="Configure RPM repositories from a .repo file or directory "
+                           "instead of kickstart. See /etc/yum.repos.d/ for example "
+                           "configuration files.")
     imgopt.add_option("", "--releasever", type="string", dest="releasever",
                       default=None,
                       help="Value to substitute for $releasever in kickstart repo urls")
@@ -197,9 +202,13 @@ def main():
         logging.error("kickstart error: %s", e)
         return 1
 
-    if not ks.handler.repo.seen:
+    if not ks.handler.repo.seen and not options.repo:
         print("Kickstart (%s) must have at least one repository." % (options.kscfg), file=sys.stderr)
         return 1
+
+    if ks.handler.repo.seen and options.repo:
+        print("Ignoring kickstart (%s) repo definitions in favor of \"%s\"" %
+              (options.kscfg, options.repo), file=sys.stderr)
 
     try:
         if options.image_type == 'livecd':
@@ -231,7 +240,7 @@ def main():
 
     try:
         creator.mount(options.base_on, options.cachedir)
-        creator.install()
+        creator.install({}, options.repo)
         if (options.flat_squashfs and
           'rd.live.overlay.overlayfs' not in ks.handler.bootloader.appendLine):
             ks.handler.bootloader.appendLine += 'rd.live.overlay.overlayfs'


### PR DESCRIPTION
This is an alternative to PR #235 with a more dnf-centric implementation.

At present, the kickstart [dialect](https://docs.fedoraproject.org/en-US/fedora/latest/install-guide/appendixes/Kickstart_Syntax_Reference/#sect-kickstart-commands-repo) cannot represent GPG keys for package signing. Package signing is required to protect against potential supply-chain attacks from untrustworthy mirrors. We can bypass this kickstart limitation by making dnf load repo configuration from a `.repo` file or a directory of the same. This is exactly how dnf works on normal, live systems.

This patch series adds the following CLI arguments:

* `--repo`: adds one or more repositories using a dnf [configuration file](https://dnf.readthedocs.io/en/latest/conf_ref.html#repo-options) or directory, just as one might find in `/etc/yum.repos.d/`. When present, all `repo` directives defined in kickstart are *ignored*. The dnf configuration files may define the `gpgkeys` and `gpgcheck` options. livecd-creator will respect GPG keys if configured and will verify packages using dnf-like logic.

* `--gpgcheck`: when present, GPG checks are strictly enforced for all packages in all repositories. Unsigned or untrusted packages will cause build errors.

This change is somewhat more invasive than my competing PR (#235) on this issue. Its main advantage is that it permits signed and unsigned packages to coexist. It also correctly maintains the key→repo association (to the extent that dnf itself does). Like my other PR, users have to opt-in to the new CLI options and behavior to gain GPG signature protection.

Closes #225
