### PR TITLE
fix: OR operator bug when target is 'live'

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -1695,8 +1695,8 @@ else
     SRC=$(readlink -f "$1") || :
 fi
 if [[ $2 == live ]]; then
-    TGTDEV=$(realpath $(readlink /run/initramfs/livedev)) || printf "
-    ERROR:  There is no running LiveOS system to target.\n\n" && exitclean
+    TGTDEV=$(realpath $(readlink /run/initramfs/livedev)) || (printf "
+    ERROR:  There is no running LiveOS system to target.\n\n" && exitclean)
 else
     TGTDEV=$(readlink -f "$2") || :
 fi


### PR DESCRIPTION
FIX the unexpected exit when using `livecd-iso-to-disk` and setting target as `live`.
Just one line modification.