### PR TITLE
Fix 'unicode.pf2' path for arm64

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -1103,7 +1103,7 @@ class aarch64LiveImageCreator(LiveImageCreatorBase):
         fail = False
         files = [("/boot/efi/EFI/*/shim%s.efi" % (self.efiarch.lower(),), "/EFI/BOOT/BOOT%s.EFI" % (self.efiarch,), True),
                  ("/boot/efi/EFI/*/gcd%s.efi" % (self.efiarch.lower(),), "/EFI/BOOT/grub%s.efi" % (self.efiarch.lower(),), True),
-                 ("/boot/efi/EFI/*/fonts/unicode.pf2", "/EFI/BOOT/fonts/", True),
+                 ("/usr/share/grub/unicode.pf2", "/EFI/BOOT/fonts/", True),
                 ]
         makedirs(isodir+"/EFI/BOOT/fonts/")
         for src, dest, required in files:


### PR DESCRIPTION
3fe2b3927e21e8a81c53baae83243100acad3b0c fixed this for x64 systems, but
the outdated paths were still present for arm64 builds.