### PR TITLE
imgcreate/creator: allow including @core group when --nocore is used

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -647,7 +647,7 @@ class ImageCreator(object):
                                        (env, e))
 
         for group in kickstart.get_groups(self.ks):
-            if group.name == 'core' or group.name in excludedGroups:
+            if (group.name == 'core' and not kickstart.nocore(self.ks)) or group.name in excludedGroups:
                 continue
 
             try:


### PR DESCRIPTION
This seems counter intuitive, but is actually useful when user wants to include mandatory `@core` packages, but skip default ones, as there is no other way to do that but something like:
```
  %packages --nocore
  @core --nodefaults
```
Similarly, with this fix this approach may be used to select optional packages from `@core` group.