### PR TITLE
imgcreate/util: don't print every word on its own line

### DIFF
--- a/imgcreate/util.py
+++ b/imgcreate/util.py
@@ -32,14 +32,12 @@ def call(*popenargs, **kwargs):
                          stderr=subprocess.STDOUT, **kwargs)
     rc = p.wait()
     fp = io.open(p.stdout.fileno(), mode="r", encoding="utf-8", closefd=False)
-    stdout = fp.read().split()
+    stdout = fp.read().splitlines(keepends=False)
     fp.close()
 
     # Log output using logging module
     for buf in stdout:
-        if not buf:
-            break
-        logging.debug("%s", buf.rstrip())
+        logging.debug("%s", buf)
 
     return rc
 


### PR DESCRIPTION
`split()` method without any arguments will return list of words, using whitespaces as separator, which then `logging.debug()` will output on separate lines,
making
mess
like
this.

Use `splitlines()` to get a list of lines and print it directly to solve that problem. Note `rstrip` is no longer needed (due to `keepends=False`), and the `break` must go away cause otherwise we would drop all output following an empty line.

 

Tested in Alma 9 container. Before:
```
Formating ext4 filesystem on /dev/loop0
Formating args: ['mkfs.ext4', '-F', '-L', '_test_vm-2022091', '-m', '1', '-b', '4096', '/dev/loop0']
mke2fs
1.46.5
(30-Dec-2021)
Discarding
device
blocks:
0/1048576
done
Creating
filesystem
with
1048576
4k
blocks
and
...
```
After:
```
Formating ext4 filesystem on /dev/loop0
Formating args: ['mkfs.ext4', '-F', '-L', '_test_vm-2022091', '-m', '1', '-b', '4096', '/dev/loop0']
mke2fs 1.46.5 (30-Dec-2021)
Discarding device blocks: done
Creating filesystem with 1048576 4k blocks and 262144 inodes
Filesystem UUID: 95fcb16d-bd85-49dc-be0e-1614080d0f55
...
```