### PR TITLE
add --nomac option to tools/livecd-creator to skip hfs image

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -68,6 +68,9 @@ class LiveImageCreatorBase(LoopImageCreator):
         self.skip_compression = False
         """Controls whether to use squashfs to compress the image."""
 
+        self.skip_hfs = False
+        """Controls whether to create a hfs boot image."""
+
         self._timeout = kickstart.get_timeout(self.ks, 10)
         """The bootloader timeout from kickstart."""
 
@@ -829,11 +832,12 @@ submenu 'Troubleshooting -->' {
     def _generate_efiboot(self, isodir):
         LiveImageCreatorBase._generate_efiboot(self, isodir)
         # add macboot data
-        subprocess.call(["mkefiboot", "-a", isodir + "/EFI/BOOT",
-                         isodir + "/isolinux/macboot.img", "-l", self.product,
-                         "-n", "/usr/share/pixmaps/bootloader/fedora-media.vol",
-                         "-i", "/usr/share/pixmaps/bootloader/fedora.icns",
-                         "-p", self.product])
+        if not self.skip_hfs:
+            subprocess.call(["mkefiboot", "-a", isodir + "/EFI/BOOT",
+                             isodir + "/isolinux/macboot.img", "-l", self.product,
+                             "-n", "/usr/share/pixmaps/bootloader/fedora-media.vol",
+                             "-i", "/usr/share/pixmaps/bootloader/fedora.icns",
+                             "-p", self.product])
 
     def _configure_bootloader(self, isodir):
         self._configure_syslinux_bootloader(isodir)

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -50,8 +50,8 @@ def parse_options(args):
                       help="Title used by syslinux.cfg file"),
     imgopt.add_option("", "--product", type="string", dest="product",
                       help="Product name used in syslinux.cfg boot stanzas and countdown"),
-    imgopt.add_option("", "--nomac", action="store_true",
-                      dest="nomac", default=False,
+    imgopt.add_option("", "--nomacboot", action="store_true",
+                      dest="nomacboot", default=False,
                       help="Do not create HFS boot image")
     # Provided for img-create compatibility
     imgopt.add_option("-n", "--name", type="string", dest="fslabel",
@@ -228,7 +228,7 @@ def main():
 
     creator.compress_args = options.compress_args
     creator.skip_compression = options.skip_compression
-    creator.skip_hfs = options.nomac
+    creator.skip_hfs = options.nomacboot
     creator.skip_minimize = options.skip_minimize
     if options.cachedir:
         options.cachedir = os.path.abspath(options.cachedir)

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -50,6 +50,9 @@ def parse_options(args):
                       help="Title used by syslinux.cfg file"),
     imgopt.add_option("", "--product", type="string", dest="product",
                       help="Product name used in syslinux.cfg boot stanzas and countdown"),
+    imgopt.add_option("", "--nomac", action="store_true",
+                      dest="nomac", default=False,
+                      help="Do not create HFS boot image")
     # Provided for img-create compatibility
     imgopt.add_option("-n", "--name", type="string", dest="fslabel",
                       help=optparse.SUPPRESS_HELP)
@@ -225,6 +228,7 @@ def main():
 
     creator.compress_args = options.compress_args
     creator.skip_compression = options.skip_compression
+    creator.skip_hfs = options.nomac
     creator.skip_minimize = options.skip_minimize
     if options.cachedir:
         options.cachedir = os.path.abspath(options.cachedir)


### PR DESCRIPTION
With command line option "--nomac", livecd-creator skips the call to mkefiboot that creates a hfs boot image. Useful for systems that does not have mkfs.hfsplus