### PR TITLE
imgcreate, editliveos: Refactor to Fedora 37 image layout.

### DIFF
--- a/docs/livecd-creator.pod
+++ b/docs/livecd-creator.pod
@@ -42,22 +42,33 @@ Defines the file system label. The default is based on the configuration name.
 
 =item --title=TITLE
 
-Title used by F<syslinux.cfg> file.
+Title used in F<syslinux.cfg> file.
 
 =item --product=PRODUCT
 
-Product name used in F<syslinux.cfg> boot stanzas and countdown.
+Product name used in boot configuration stanzas and countdown.
 
-=item --repo=PATH
+=item --releasever=VER
 
-Configure RPM repositories from the given file or directory of L<dnf.conf(5)>
-C<.repo> files. C<%repo> directives in the kickstart file will be ignored.
+Set the value to substitute for $releasever in kickstart repo urls.
 
-=item  -p, --plugins
+=item --syslinux
 
-Use DNF plugins during image creation.
+Use SYSLINUX for BIOS booting (default: False).
 
-=item --compression-type=COMPRESS_ARGS
+=item --nomacboot
+
+Do not create an HFS+ boot image and partition (default: False). Only
+operative when SYSLINUX BIOS booting is called (as HFS boot images are not
+needed or standard).
+
+=item --flat-squashfs
+
+Specify squashing the root filesystem directly. This eliminates the
+intermediate LiveOS directory holding another filesystem image file.  This is
+suitable only for OverlayFS overlays. (default=False).
+
+=item --compression-type="TYPE ARG1 ARG2 ..."
 
 Specify a compressor recognized by mksquashfs.
 C<xz> is the default and works with 2.6.38 and later kernels.
@@ -69,9 +80,28 @@ Set to C<None> to force reading the compressor used in BASE_ON.
 If C<gzip> is used, the -comp option is not passed to mksquashfs to allow the use of older versions of mksquashfs.
 Multiple arguments should be specified in one string, i.e., C<--compression-type "type arg1 arg2 ...">.
 
-=item --releasever=VER
+=item --dracut-args="[+]ARG0 ARG1 ..."
 
-Set the value to substitute for $releasever in kickstart repo urls.
+The arguments that will be used by dracut to configure the initrd and be saved
+at F</etc/dracut.conf.d/99-liveos.conf>. This file persists only for the life of
+the install_root mount.  (A pending version of dracut will save this file in
+the initrd under F<*/lib/dracut/conffiles/> or another regular path.) Each argument
+consists of an attribute and a value (see L<dracut.conf(5)>).
+
+If the first argument string is prefixed with a '+' character, the additional
+arguments will be appended to the default set (superseding any there):
+
+  mdadmconf=no
+  lvmconf=no
+  compress=xz
+  add_dracutmodules+=" livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net "
+  omit_dracutmodules+=" plymouth "
+  hostonly=no
+  early_microcode=no
+
+=item  -p, --plugins
+
+Use DNF plugins during image creation.
 
 =item --pkgverify-level=LEVEL
 
@@ -104,6 +134,15 @@ These options define directories used on your system for creating the live image
 
 defines the temporary directory to use. The default directory is F</var/tmp>.
 
+=item -o, PATH --output=PATH
+
+The output directory path where the image .iso will be saved (default: F<'.'>).
+
+=item --repo=PATH
+
+Configure RPM repositories from the given file or directory of L<dnf.conf(5)>
+C<.repo> files. C<%repo> directives in the kickstart file will be ignored.
+
 =item --cache=CACHEDIR
 
 Defines the cache directory to use (default: private cache).
@@ -112,9 +151,17 @@ Defines the cache directory to use (default: private cache).
 
 Work offline from cache, use together with --cache (default: False).
 
+=item -l, --shell
+
+Launch a change root shell in the installation root filesystem.
+This includes bind mounts to the host directories F</dev>, F</dev/pts>,
+F</dev/shm>, F</proc>, F</sys>, F</sys/fs/selinux>, the creator iso stageing
+directory (mounted at F</run/iso>), and the host root filesystem (mounted at
+F</run/hostroot>).  Useful for F<ad hoc> custimization during a build session.
+
 =item --nocleanup
 
-Skip cleanup of temporary files.
+Skip cleanup of temporary files (default: False).
 
 =back
 
@@ -146,14 +193,14 @@ Save debug information to FILE.
 
 Barebones LiveCD
 
-livecd-creator \
---config=/usr/share/livecd-tools/livecd-fedora-minimal.ks
+  livecd-creator \
+    --config=/usr/share/livecd-tools/livecd-fedora-minimal.ks
 
 Fedora Desktop Live CD
 
-livecd-creator \
---config=/usr/share/livecd-tools/livecd-fedora-desktop.ks \
---fslabel=Fedora9-LiveCD-foo
+  livecd-creator \
+    --config=/usr/share/livecd-tools/livecd-fedora-desktop.ks \
+    --fslabel=Fedora9-LiveCD-foo
 
 =head1 REPO EXTENSIONS
 
@@ -163,7 +210,7 @@ are replaced with the system arch, basearch and release version respectively.
 When no --releasever is passed it defaults to the current system's version.
 This allows the use of repo commands such as the following:
 
-repo --name=fedora --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
+  repo --name=fedora --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 
 Note that in a chroot environment (like koji) the rpmdb is not available,
 so either don't use $releasever in that case, or pass --releasever=VER.
@@ -209,10 +256,10 @@ Report bugs to the mailing list L<http://www.redhat.com/mailman/listinfo/fedora-
 
 =head1 COPYRIGHT
 
-Copyright (C) Fedora Project 2008,2009,2020, and various contributors. This is free software. You may redistribute copies of it under the terms of the GNU General Public License L<http://www.gnu.org/licenses/gpl.html>. There is NO WARRANTY, to the extent permitted by law.
+Copyright (C) Fedora Project 2008,2009,2020,2023 and various contributors. This is free software. You may redistribute copies of it under the terms of the GNU General Public License L<http://www.gnu.org/licenses/gpl.html>. There is NO WARRANTY, to the extent permitted by law.
 
 =head1 SEE ALSO
 
-L<livecd-iso-to-disk(8)>, L<dnf.conf(5)>, project website L<http://fedoraproject.org/wiki/FedoraLiveCD>
+L<livecd-iso-to-disk(8)>, L<dnf.conf(5)>, L<dracut.conf(5)>, project website L<http://fedoraproject.org/wiki/FedoraLiveCD>
 
 =cut

--- a/imgcreate/dnfinst.py
+++ b/imgcreate/dnfinst.py
@@ -23,7 +23,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-from __future__ import print_function
 import glob
 import os
 import os.path

--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -4,6 +4,7 @@
 # Copyright 2007, Red Hat  Inc.
 # Copyright 2016, Kevin Kofler
 # Copyright 2016, Neal Gompa
+# Copyright 2023, Fedora Project
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -528,6 +529,7 @@ class SelinuxConfig(KickstartConfig):
                 else:
                     f.write(line)
 
+        print('Setting SELinux contexts...')
         self.relabel(ksselinux, policy_name)
 
     def find_policy_file(self, policy_name):
@@ -564,7 +566,7 @@ def get_timeout(ks, default = None):
         return default
     return int(ks.handler.bootloader.timeout)
 
-def get_kernel_args(ks, default = "ro rd.live.image quiet"):
+def get_kernel_args(ks, default="ro rd.live.image"):
     if not hasattr(ks.handler.bootloader, "appendLine"):
         return default
     if ks.handler.bootloader.appendLine is None:

--- a/imgcreate/util.py
+++ b/imgcreate/util.py
@@ -42,8 +42,8 @@ def call(*popenargs, **kwargs):
     return rc
 
 def rcall(args, stdin='', raise_err=True, cwd=None, env=None):
-    """Return stdout, stderr, & returncode from a subprocess call."""
-
+    """Return stdout, stderr, & returncode from a subprocess call.
+    """
     out, err, p, environ = '', '', None, None
     if env is not None:
         environ = os.environ.copy()

--- a/tools/editliveos
+++ b/tools/editliveos
@@ -41,7 +41,7 @@ doc2 = '''
               /path/to/build.iso, or, if mounted, through the mount point
               directory path.  A Live CD-ROM image is addressed through its
               device node, such as /dev/sr0.  Even a directory containing a
-              LiveOS and iso/syslinux folders with the appropriate files can
+              LiveOS and bootpath folders with the appropriate files can
               be edited or cloned through that parent directory path.
 
               The --clone option copies the home.img filesystem to the new
@@ -90,10 +90,10 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [-N, --noshell]
                         [-t, --tmpdir <tmpdir>]
                         [-f, --dnfcache, -y, --yumcache <cachedir>]
-                        [-e, --exclude <exclude s>]
-                        [-i, --include <include s>]
-                        [-u, --seclude <seclude s>]
-                        [-r, --releasefile <releasefile s>]
+                        [-e, --exclude <"exclude paths">]
+                        [-i, --include <"include paths">]
+                        [-u, --seclude <"seclude paths">]
+                        [-r, --releasefile <"releasefile paths">]
                         [-b, --builder <builder>]
                         [-p, --plugins]
                         [--clone]
@@ -102,7 +102,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [--refresh-only]
                         [--skip-refresh]
                         [--skip-seclude]
-                        [-c, --compress-type <compression arg s>]
+                        [-c, --compress-type <"compression arg s">]
                         [--compress]
                         [--releasever <value to substitute for $releasever in repo urls>]
                         [--arch <image arch>]
@@ -114,7 +114,8 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                         [--encrypted-home]
                         [--unencrypted-home]
                         [--overlay-size-mb [+|-]<size>[,<fstype>[,<blksz>]]]
-                        [-a, --extra-kernel-args <arg s>]
+                        [-a, --extra-kernel-args <"arg s">]
+                        [--dracut-args <"[+]arg s">]
                         [--extra-space-mb <size>]
                         [--cacheonly]
                         [--nocleanup]
@@ -161,22 +162,22 @@ parser.add_argument('-t', '--tmpdir', default='/var/tmp', metavar='PATH',
                     help='Temporary directory to use for staging the build.\n'
                          'default = /var/tmp\n ')
 
-parser.add_argument('-f', '--dnfcache', '-y', '--yumcache', dest='cachedir', 
+parser.add_argument('-f', '--dnfcache', '-y', '--yumcache', dest='cachedir',
                     metavar='PATH',
                     help='Directory to use for for the DNF or Yum cache.\n'
                          'Bind mounts to /var/cache/dnf and /var/cache/yum\n'
                          'will be created.    default = None  (A temporary\n'
                          'filesystem cache will be used.)\n ')
 
-parser.add_argument('-e', '--exclude', dest='excludes', metavar='PATH',
+parser.add_argument('-e', '--exclude', dest='excludes', metavar='"PATH ..."',
     help='A string of filename patterns to exclude from the copy\nof the '
     'outer device filesystem.  See _copy_src_root().\nDenote multiple '
     'patterns as "pattern1 pattern2 ..."\nThe default is to exclude all '
-    'device content except for\nthe iso/syslinux, EFI, and LiveOS directories. '
+    'device content except for\nthe bootpath, EFI, and LiveOS directories. '
     'Entering\nanything to be excluded will have the effect of\nincluding '
     'everything else but the excluded items.\n ')
 
-parser.add_argument('-i', '--include', dest='includes', metavar='PATH',
+parser.add_argument('-i', '--include', dest='includes', metavar='"PATH ..."',
     help='A string of file or directory paths to copy to the .iso\nfile in '
     '_copy_src_root().  Denote multiple files as\n"path1 path2 ..."  '
     '(The paths are referenced\nrelative to the source mount directory, '
@@ -186,7 +187,7 @@ parser.add_argument('-i', '--include', dest='includes', metavar='PATH',
     '../../../../<mount point>/INCLUDE may be used,\nrespectively, to '
     'include files from other branches of\nthe active hierarchy.)\n ')
 
-parser.add_argument('-u', '--seclude', dest='secludes', metavar='PATH',
+parser.add_argument('-u', '--seclude', dest='secludes', metavar='"PATH ..."',
     help='A string of file or directory paths in the LiveOS\nfilesystem to '
     'seclude from the final build\nconfiguration. The user directory may '
     'be denoted with\n~/.  Denote multiple files as "path1 path2 ..."\n'
@@ -194,14 +195,14 @@ parser.add_argument('-u', '--seclude', dest='secludes', metavar='PATH',
     'secluded from the packaged iso image.\nSee seclude_from_isoimage() '
     'and scrub_system() in the\ncode for the specific files.\n ')
 
-parser.add_argument('-r', '--releasefile', metavar='PATH',
+parser.add_argument('-r', '--releasefile', metavar='"PATH ..."',
                     help='Specify release file/s for branding the build.\n'
                          'Denote multiple files as "path1 path2 ..."\n ')
 
-parser.add_argument('-b', '--builder', default=os.getenv('USERNAME'),
+parser.add_argument('-b', '--builder', default=os.getenv('USERNAME', 'Somebody'),
                     help='Specify the builder of a Remix.\n'
-                         'default = "' + os.getenv('USERNAME') + '" (the '
-                         'current system user)\n ')
+                         'default = "' + os.getenv('USERNAME', 'Somebody') +
+                          '" (the current system user)\n ')
 
 parser.add_argument('--clone', action='store_true', default=False,
                     help='Specify copying of the home.img filesystem or\nthe'
@@ -295,7 +296,7 @@ parser.add_argument('--skip-refresh', action='store_true', default=False,
 parser.add_argument('--skip-seclude', action='store_true', default=False,
                     help='Specify no seclusion of specific user files.\n ')
 
-parser.add_argument('-c', '--compress-type', metavar='ARGS',
+parser.add_argument('-c', '--compress-type', metavar='"TYPE ARG1 ARG2 ..."',
                     help='Specify the compression type for SquashFS.\nThis '
                          'will override the current compression or lack\n'
                          'thereof.  Multiple arguments should be specified '
@@ -330,11 +331,32 @@ parser.add_argument('--flatten-squashfs', action="store_true",
                          '\noption.\n ')
 
 parser.add_argument('-a', '--extra-kernel-args', dest='kernelargs',
-                    metavar='ARGS', default='',
+                    metavar='"ARG0 ARG1 ..."', default='',
                     help='Specify extra kernel arguments to include in the '
                          'new\n.iso file boot configuration.  Multiple '
                          'arguments\nshould be specified in one string, '
                          'i.e.,\n--extra-kernel-args "arg1 arg2 ..."\n ')
+
+parser.add_argument('--dracut-args', dest='dracut_args', default='',
+                    metavar='"[+]ARG0 ARG1 ..."',
+                    help='The arguments to be used by dracut to configure '
+                    'the initrd.\nSaved at /etc/dracut.conf.d/99-liveos.conf. '
+                    'This file persists\nonly for the life of the install_root '
+                    'mount. (A future version\nof dracut will save this file '
+                    'in the initrd under\n/usr/lib/dracut/conffiles/ or '
+                    'another regular path.)  Multiple\narguments should be '
+                    'specified in one string, i.e.,\n--dracut-args "[+]arg1 arg2 ..." '
+                    ' Each argument consists of\nan attribute and a value (see '
+                    'dracut.conf.5). If the first\nargument is prefixed with a '
+                    '\'+\' character, the additional\narguments will be appended '
+                    'to the default set\n(superseding any there):\n\n'
+                      'mdadmconf=no\n'
+                      'lvmconf=no\n'
+                      'compress=xz\n'
+                      'add_dracutmodules+=" livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net "\n'
+                      'omit_dracutmodules+=" plymouth "\n'
+                      'hostonly=no\n'
+                      'early_microcode=no\n ')
 
 parser.add_argument('--extra-space-mb', type=int, default=2, metavar='SIZE',
                     help='Specify extra space in MiB to reserve for\n'
@@ -343,19 +365,19 @@ parser.add_argument('--extra-space-mb', type=int, default=2, metavar='SIZE',
 parser.add_argument('--nocleanup', action='store_true', default=False,
                     help='Skip cleanup of temporary files.\n ')
 
-parser.add_argument('--releasever', type=str, dest='releasever', 
-                    default=None, 
+parser.add_argument('--releasever', type=str, dest='releasever',
+                    default=None,
                     help='Value to substitute for $releasever in kickstart '
                          'repo urls.\n ')
 
 parser.add_argument('--arch', type=str, dest='arch', 
-                    default=dnf.rpm.basearch(hawkey.detect_arch()), 
+                    default=dnf.rpm.basearch(hawkey.detect_arch()),
                     help='Computer instruction set architecture for the '
                          'final image.\n'
                          'default = dnf.rpm.basearch(hawkey.detect_arch())\n ')
 
 parser.add_argument('-p', '--plugins', action='store_true', dest='plugins',
-                    default=False, 
+                    default=False,
                     help='Use DNF plugins during image creation.\n ')
 
 parser.add_argument('--cacheonly', action='store_true', dest='cacheonly',
@@ -417,19 +439,22 @@ class LiveImageEditor(LiveImageCreator):
         """A string of filename patterns to exclude from the copy of the outer
         device filesystem.  See _copy_src_root().  Denote multiple patterns as
         "pattern1, pattern2, ..."  Default is all content outside of the LiveOS
-        and iso/syslinux directories."""
+        and bootpath directories."""
 
         self.secludes = []
         """A string of file or directory paths to seclude from the built .iso
         file but maintain (restore to) in the refreshed filesystems."""
 
+        self.product = ''
+        """A string providing the product name or release name."""
+
         self.releasefile = []
         """A string of file or directory paths to include in _brand().  This
         variable is later reused to hold the modified release name."""
 
-        self.builder = os.getenv('USERNAME')
+        self.builder = os.getenv('USERNAME', 'Somebody')
         """The name of the Remix builder for _branding.
-        Default = os.getenv('USERNAME')"""
+        Default = os.getenv('USERNAME', 'Somebody')"""
 
         self.compress_args = None
         """mksquashfs compressor to use. Use 'None' to force reading of the
@@ -444,6 +469,15 @@ class LiveImageEditor(LiveImageCreator):
         self.root_fstype = None
 
         self.root_blksz = None
+
+        self._imgdir = 'images/pxeboot'
+        """Directory for kernel and initrd images."""
+
+        self._losdn = ''
+        """Escaped liveosdir name for sed scripts."""
+
+        self.skip_hfs = False
+        """Controls whether to create a hfs boot image."""
 
         self._ImageCreator__builddir = None
         """The staging directory for the build contents and mount points."""
@@ -550,9 +584,8 @@ class LiveImageEditor(LiveImageCreator):
 
         base_on --  the <LiveOS_source> a LiveOS.iso file, an attached LiveOS
                     device, such as, /dev/sdd1 (or similar), the path to a
-                    directory or mount point containing the LiveOS and iso/
-                    syslinux folders, or "live" for a currently running LiveOS
-                    image.
+                    directory or mount point containing the LiveOS and bootpath
+                    folders, or "live" for a currently running LiveOS image.
         rootfsimg - An optional <file path> to the root filesystem image
                     relative to the mount point for the <LiveOS_source>.
         overlay   - An optional [<devspec>:]<path> to the overlay device and
@@ -579,7 +612,7 @@ class LiveImageEditor(LiveImageCreator):
         self.ovl_size = 0
         if self.src_type == 'live':
             src = os.path.join('/run', 'initramfs', 'isoscandev')
-                # (^ Requires dracut verion 051 or greater.)
+                # (^ Requires dracut version 051 or greater.)
             if os.path.exists(src):
                 base_on = os.path.realpath(os.readlink(src))
                 src = os.path.join('/proc', 'cmdline')
@@ -747,6 +780,7 @@ class LiveImageEditor(LiveImageCreator):
                 self._LoopImageCreator__fstype = findmnt('-no FSTYPE', img)
         else:
             self.liveosdir = self.liveosmnt.liveosdir
+            losm = self.liveosmnt
             img = losm.imgloop.device
             self._LoopImageCreator__fstype = losm.imgloop.fstype
 
@@ -766,13 +800,18 @@ class LiveImageEditor(LiveImageCreator):
             self._LoopImageCreator__fstype = self.root_fstype
         if not os.path.exists(self.liveosdir):
             raise CreatorError("No LiveOS directory on %s" % base_on)
-        self.bootfolder = os.path.join(self.srcdir, 'syslinux')
         self.imagesdir = os.path.join(self.srcdir, 'images')
+        self.bootdir = os.path.join(self.srcmntdir, 'boot')
+        self.bootpath = os.path.join(self.imagesdir, 'pxeboot')
+        bootpath = os.path.join(self.srcdir, 'syslinux')
         if not os.path.exists(self.imagesdir):
             self.imagesdir = os.path.join(self.srcmntdir, 'images')
-            self.bootfolder = os.path.join(self.srcmntdir, 'syslinux')
-        if not os.path.exists(self.bootfolder):
-            self.bootfolder = os.path.join(self.srcdir, 'isolinux')
+            self.bootpath = os.path.join(self.imagesdir, 'pxeboot')
+            bootpath = os.path.join(self.srcmntdir, 'syslinux')
+        if not os.path.exists(bootpath):
+            bootpath = os.path.join(self.srcdir, 'isolinux')
+        if os.path.exists(bootpath):
+            self.bootpath = bootpath
 
         self.home_img = os.path.join(self.liveosdir, 'home.img')
         self.isohome_img = os.path.join(self._LiveImageCreatorBase__isodir,
@@ -837,7 +876,7 @@ class LiveImageEditor(LiveImageCreator):
         attached, or refreshed device.  Optionally, pass a rootfsimg or
         overlay reference.
         """
-        if os.path.isfile(base_on):
+        if os.path.isfile(base_on) or self.src_type == 'iso':
             self.liveossrc = DiskMount(LoopbackDisk(base_on, None, '-r'),
                              tempfile.mkdtemp(dir=mntdir, prefix='iso-'))
             self.srcdir = self.liveossrc.mountdir
@@ -1024,7 +1063,7 @@ class LiveImageEditor(LiveImageCreator):
         if self.exclude_all:
             files0from = os.path.join(self.srcdir)
             files0from = '\0'.join((files0from, os.path.join(srcmntdir,
-                                    os.path.basename(self.bootfolder))))
+                                    os.path.basename(self.bootpath))))
         elif not self.refresh_only:
             for i, fn in enumerate(self.includes):
                 src = os.path.join(srcmntdir, fn.lstrip(os.sep))
@@ -1157,7 +1196,8 @@ class LiveImageEditor(LiveImageCreator):
         isodir = self._LiveImageCreatorBase__isodir
 
         ignore_list = [self.rootfs_img, 'squashfs.img', 'ovlwork', 'osmin.img',
-         'home.img', 'swap.img', 'overlay-*', 'images', 'syslinux', 'isolinux']
+         'home.img', 'swap.img', 'overlay-*', 'images', 'syslinux', 'isolinux',
+         'boot']
         if self.clone and not self.home_size_mb and self.EncHomeReq is None:
             ignore_list.remove('home.img')
 
@@ -1178,8 +1218,12 @@ class LiveImageEditor(LiveImageCreator):
         shutil.copytree(src, dst, symlinks=True,
                         ignore=shutil.ignore_patterns(*ignore_list))
 
-        for src in (self.bootfolder, self.imagesdir):
-            copypaths([src], isodir)
+        if os.path.exists(self.bootdir):
+            copypaths([self.bootdir], isodir)
+            self.bootdir = isodir + '/boot'
+        copypaths([self.imagesdir], isodir)
+        if 'linux' in self.bootpath:
+            copypaths([self.bootpath], isodir)
 
         for src in ('LICENSE', 'Fedora-Legal-README.txt', 'EFI'):
             src = os.path.join(self.srcmntdir, src)
@@ -1202,7 +1246,7 @@ class LiveImageEditor(LiveImageCreator):
                     if os.path.exists(link):
                         os.unlink(link)
                         os.symlink(os.path.join('../..', os.path.basename(
-                                                   self.bootfolder), fn), link)
+                                                   self.bootpath), fn), link)
 
         if os.path.exists(self.isohome_img):
             print('Checking home.img')
@@ -1414,9 +1458,9 @@ class LiveImageEditor(LiveImageCreator):
                 os.mknod(urandom, 0o666 | stat.S_IFCHR, os.makedev(1, 9))
                 os.umask(origumask)
 
-            bindmounts = [('/sys', None), ('/proc', None), ('/dev/pts', None),
-                          ('/dev/shm', None), ('/run', None),
-                          ('/etc/resolv.conf', None),
+            bindmounts = [('/proc', None), ('/run', None), ('/sys', None),
+                          ('/dev', None), ('/dev/pts', None),
+                          ('/dev/shm', None), ('/etc/resolv.conf', None),
                           (cachesrc, '/var/cache/dnf'),
                           (cachesrc, '/var/cache/yum'),
                           (self._LiveImageCreatorBase__isodir, '/mnt/live'),
@@ -1465,23 +1509,28 @@ class LiveImageEditor(LiveImageCreator):
             cmd = ['sort', '-rV']
             a, err, rc = rcall(cmd, '\n'.join(self.kernels))
             a = a.split('\n')[0]
+            # Update to latest kernel & initrd.
             if self.kernels != self.kernels0 or self.initrd_kernel != a:
                 print('Updating kernel & initial ram filesystem images...')
                 rc = os.path.join(self._instroot, 'boot',
                                                    'initramfs-' + a + '.img')
                 d = os.path.join(self._instroot, 'usr', 'lib', 'modules', a)
-                cmd = ['dracut', rc, '--kmoddir', d, '--kver', a,
-                       '--no-hostonly', '--add', 'dmsquash-live', '--force']
+                # '--sysroot' argument requires dracut version 051 or greater.
+                cmd = ['dracut', rc, '--sysroot', self._instroot, '--kmoddir',
+                       d, '--kver', a, '--zstd', '--no-hostonly', '--add',
+                       'dmsquash-live', '--force']
                 if self.src_fstype == 'f2fs':
                     cmd += ['--add-drivers', 'f2fs']
                 print('using this command:\n%s' % cmd)
                 call(cmd)
                 a = os.path.join(d, vm)
-                imagedirs = [self.bootfolder,
+                imagedirs = [self.bootpath,
                   os.path.join(self.imagesdir, 'pxeboot'),
                   os.path.join(self._LiveImageCreatorBase__isodir, 'isolinux'),
                   os.path.join(self._LiveImageCreatorBase__isodir, 'images',
                                'pxeboot')]
+                if not 'linux' in self.bootpath:
+                    del imagedirs[2]
                 if not os.access(imagedirs[1], os.W_OK):
                     del imagedirs[0:2]
                 [shutil.copy2(rc, os.path.join(d, img)) for d in imagedirs]
@@ -1529,7 +1578,7 @@ class LiveImageEditor(LiveImageCreator):
             elif s == 's' and 'current' in msg:
                 self.shell = True
             elif s == 's':
-                self.launch_shell()
+                self.launch_shell(PS1='[\\u@\\H:install_root\\w:]\\n\\$ ')
                 self.check_kernel_versions(isodir, msg)
 
 
@@ -1538,18 +1587,43 @@ class LiveImageEditor(LiveImageCreator):
         Adjust the image branding to show its variation from the original
         source by name, builder, and build date.
         """
+
+        if os.path.exists(self.liveosdir + '/images'):
+            # Escape directory name.
+            self._losdn = _esc(os.path.basename(self.liveosdir.rstrip('/')))
+        else:
+            self._losdn = ' '
+
+        for dn in ('BOOT', 'boot'):
+            EFI_config = os.path.join(isodir, 'EFI', dn, 'grub.cfg')
+            if os.path.exists(EFI_config):
+                break
+            else:
+                EFI_config = None
+        self.EFI_config = EFI_config
+
         for f in ('isolinux.cfg', 'syslinux.cfg', 'extlinux.conf'):
-            self.cfgf = os.path.join(isodir, f)
-            if os.path.exists(self.cfgf): break
+            self.cfgf = os.path.join(isodir, 'isolinux', f)
+            if os.path.exists(self.cfgf):
+                break
+        if os.path.exists(self.cfgf):
+            self._imgdir = 'isolinux'
+            self.BIOSbooter = 'SYSLINUX'
+            sedscript = r'''/^\s*label\s+linux/I {n
+                  s/^\s*menu\s+label\s+\^\S+\s+(.*)/\1/Ip;q}'''
+        else:
+            self.cfgf = self.EFI_config
+            self.BIOSbooter = 'GRUB'
+            #FIXME: limited to first matching menu item.
+            sedscript = r'''
+/^menuentry/ s/.*Start\s*{0}( ~|)(.*)'\s+.*/\2/ p'''.format(self._losdn)
         # Get release name from boot configuration file.
         cmd = ['sed', '-n', '-r']
-        sedscript = r'''/^\s*label\s+linux/I {n
-                      s/^\s*menu\s+label\s+\^\S+\s+(.*)/\1/Ip;q}'''
         cmd.extend([sedscript, self.cfgf])
         release, err, rc = rcall(cmd)
         if not release:
             return
-        self.release = release = release.strip()
+        self.product = release = release.strip()
         f = release.find('Remix-')
         if f > -1:
             release = release[f+6:]
@@ -1597,83 +1671,96 @@ class LiveImageEditor(LiveImageCreator):
                         f.close()
             self.releasefile = nametext
 
-        sedscript = r'''/^\s*label\s+linux/I {n;n;n
-                      s/^\s*append\s+initrd=\S+\s+(.*)/\1/Ip;q}'''
-        cmd[3:] = [sedscript, self.cfgf]
-        self.kcmdline0, err, rc = rcall(cmd)
-        self.kcmdline0 = self.kcmdline0.rstrip()
-
 
     def _configure_bootloader(self, isodir):
         """Restore the boot configuration files for an iso image boot."""
 
-        isocfgf = os.path.join(isodir, 'isolinux', 'isolinux.cfg')
+        isocfgf = os.path.join(isodir, self._imgdir, 'isolinux.cfg')
         if os.path.exists(isocfgf):
             self.cfgf = isocfgf
-        else:
+        elif 'linux' in self.cfgf:
             os.rename(self.cfgf, isocfgf)
+        else:
+            isocfgf = None
+
+        if 'linux' in self.cfgf:
+            sedscript = r'''/^\s*label\s+linux/I {n;n;n
+                            s/^\s*append\s+initrd=\S+\s+(.*)/\1/Ip;q}'''
+        else:
+            self.cfgf = self.EFI_config
+            #FIXME: limited to first matching menu item.
+            sedscript = r'''
+0,/^\s*linuxefi\s*\/{0}/ s/^\s*linuxefi\s*\/{0}\S+vmlinuz?*\s+(.*)/\1/p'''.format(self._losdn)
+        cmd = ['sed', '-n', '-r', sedscript, self.cfgf]
+        self.kcmdline0, err, rc = rcall(cmd)
+        self.kcmdline0 = self.kcmdline0.rstrip()
 
         cmd = ['sed', '-i', '-r']
-
-        for dn in ('BOOT', 'boot'):
-            EFI_config = os.path.join(isodir, 'EFI', dn, 'grub.cfg')
-            if os.path.exists(EFI_config):
-                break
-            else:
-                EFI_config = None
-        self.EFI_config = EFI_config
-
         # Keep only the menu entries up through the first submenu.
         sedscript = r'''/\s+}$/ { N
                         /\n}$/ { n;Q}}'''
-        cmd.extend([sedscript, EFI_config])
+        cmd.extend([sedscript, self.EFI_config])
         call(cmd)
         # Remove a netinst Rescue submenu.
         sedscript = r'''/^\s*menuentry 'Rescue .*/I {N;N;N;d}'''
-        cmd[3:] = [sedscript, EFI_config]
+        cmd[3:] = [sedscript, self.EFI_config]
         call(cmd)
 
-        # Remove labels from any multi boot configurations.
-        sedscript = r'''/^\s*label .*/I,/^\s*label linux\>/I{
-                        /^\s*label linux\>/I ! {N;N;N;N
-                        /\<kernel\s+[^ ]*menu.c32\>/d};}'''
-        cmd[3:] = [sedscript, isocfgf]
-        call(cmd)
-        sedscript = r'''/^\s*menu\s+end/I,$ {
-                        /^\s*menu\s+end/I ! d}'''
-        cmd[3:] = [sedscript, isocfgf]
-        call(cmd)
+        if isocfgf:
+            # Remove labels from any multi boot configurations.
+            sedscript = r'''/^\s*label .*/I,/^\s*label linux\>/I{
+                            /^\s*label linux\>/I ! {N;N;N;N
+                            /\<kernel\s+[^ ]*menu.c32\>/d};}'''
+            cmd[3:] = [sedscript, isocfgf]
+            call(cmd)
+            sedscript = r'''/^\s*menu\s+end/I,$ {
+                            /^\s*menu\s+end/I ! d}'''
+            cmd[3:] = [sedscript, isocfgf]
+            call(cmd)
+        else:
+            sedscript = r'''s;syslinux;images\/pxeboot;'''
+            cmd[3:] = [sedscript, self.EFI_config]
+            call(cmd)
 
-        sedscript = r'''s/(root=[^ ]*|inst.stage2=[^ ]*)/root=live:CDLABEL={0}/
+        sedscript = r'''0,/^menuentry/ s/.*'Start\s+(\S+\s+~|)(.*)'\s+.*/\2/ p'''
+        # Get release name from boot configuration file.
+        cmd = ['sed', '-n', '-r']
+        cmd.extend([sedscript, self.cfgf])
+        release, err, rc = rcall(cmd)
+        release = release.rstrip()
+
+        sedscript = r'''s/(search\s+.*--set=root\s+-).*/\1l '{0}'/
+s/(root=[^ ]*|inst.stage2=[^ ]*)/root=live:CDLABEL={0}/
 s/^\s*timeout\s+.*/timeout 600/I
 /^\s*totaltimeout\s+.*/Iz
 s/\<{1}\>/{2}/g
 /^\s*append|linuxefi/I s/\<rd\.live\.[^c]\S+\s+//2g
-'''.format(self.fslabel, self.release, self.releasefile)
-        cmd = ['sed', '-i', '-r', sedscript, isocfgf]
-        if EFI_config:
-            cmd.append(EFI_config)
+'''.format(_esc(self.fslabel), _esc(release), _esc(self.releasefile))
+        cmd = ['sed', '-i', '-r', sedscript]
+        if isocfgf:
+            cmd.append(isocfgf)
+        if self.EFI_config:
+            cmd.append(self.EFI_config)
         call(cmd)
-
-        sedscript = r'''s/\<(kernel)\>\s+\S*(vmlinuz.?)/\1 \2/
+        if isocfgf:
+            sedscript = r'''s/\<(kernel)\>\s+\S*(vmlinuz.?)/\1 \2/
 /\s+append/I {{
 s/\<(initrd=).*(initrd.?\.img)\>/\1\2/
 s/\s+rw\>//g}}'''
-        cmd[3:] = [sedscript, isocfgf]
-        call(cmd)
+            cmd[3:] = [sedscript, isocfgf]
+            call(cmd)
 
-        if EFI_config:
-            iso_boot = os.path.join('images', 'pxeboot')
+        if self.EFI_config:
+            iso_boot = 'images/pxeboot'
             if not os.path.exists(os.path.join(isodir, iso_boot)):
                 iso_boot = 'isolinux'
             sedscript = r'''/^\s*insmod\s+(fat|xfs|f2fs|btrfs)\s*$/ s/(fat|xfs|f2fs|btrfs)/ext2/
-s/(--set=root ).+'/\1-l '{0}'/
 s/^\s*set\s+timeout=.*/set timeout=60/
-s_(linuxefi|initrdefi)\s+\S+(vmlinuz.?|initrd.?\.img)_\1 /{1}/\2_
+s_(linuxefi|initrdefi)\s+\S+(vmlinuz.?|initrd.?\.img)_\1 /{0}/\2_
 /^\s*menuentry/ {{
-s/\S+\s+~{2}/{2}/
-s/\s+rw\>//g}}'''.format(self.fslabel, iso_boot, self.releasefile)
-            cmd[3:] = [sedscript, EFI_config]
+s/\S+\s+~{1}/{1}/
+s/\s+rw\>//g}}'''.format(_esc(iso_boot), _esc(self.releasefile))
+            cmd[3:] = [sedscript, self.EFI_config]
             call(cmd)
 
         sedscript = r'''/^\s*append|linuxefi/I {{
@@ -1682,7 +1769,7 @@ s/\s+rw\>//g}}'''.format(self.fslabel, iso_boot, self.releasefile)
             self.kernelargs = 'rd.live.overlay.overlayfs ' + self.kernelargs
         if self.kernelargs:
             sedscript += r'''s/\s+(rd\.live\.image|liveimg)(.*)$/ \1 {0} \2/
-'''.format(self.kernelargs)
+'''.format(_esc(self.kernelargs))
         if self.ks:
             # bootloader --append "!opt-to-remove opt-to-add"
             for param in kickstart.get_kernel_args(self.ks, "").split():
@@ -1696,12 +1783,15 @@ s/\s+rw\>//g}}'''.format(self.fslabel, iso_boot, self.releasefile)
                     sedscript += r'''s/$/ %s/
 ''' % param
 
-        sedscript += r''':w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw
+        # Remove duplicate words, double spaces, & space at line end.
+        sedscript += r''':w;s/(\s+\S+)\s+(.*)\1(\s+|$)/\1 \2\3/g;tw
 s/\>\s\s+/ /g
 s/\s+$//}}'''
-        cmd[3:] = [sedscript, isocfgf]
-        if EFI_config:
-            cmd.append(EFI_config)
+        cmd[3:] = [sedscript]
+        if isocfgf:
+            cmd.append(isocfgf)
+        if self.EFI_config:
+            cmd.append(self.EFI_config)
 
         try:
             call(cmd)
@@ -1716,12 +1806,37 @@ s/\s+$//}}'''
         if os.path.exists(isocfgf):
             os.remove(isocfgf)
         # Synchronize redundant configuration files.
-        EFI_config = os.path.join(os.path.dirname(EFI_config), 'BOOT.conf')
+        EFI_config = os.path.join(os.path.dirname(self.EFI_config), 'BOOT.conf')
         shutil.copy2(self.EFI_config, EFI_config)
         EFI_config = EFI_config + '.prev'
         if os.path.exists(EFI_config):
             os.remove(EFI_config)
 
+        if os.path.exists(self.bootdir):
+            chain = '''	menuentry 'Boot first drive' --class fedora --class gnu-linux --class gnu --class os {
+		chainloader (hd0)+1
+	}
+	menuentry 'Boot second drive' --class fedora --class gnu-linux --class gnu --class os {
+		chainloader (hd1)+1
+	}
+}'''
+            EFI_config = self.bootdir + "/grub2/grub.cfg"
+            shutil.copy2(self.EFI_config, EFI_config)
+            sedscript = r'''/^\s+insmod\s+(efi_gop|efi_uga|video_bochs|video_cirrus)/ d
+/^\s*insmod\s+part_/ a insmod chain
+s/linuxefi/linux/
+s/initrdefi/initrd/
+$,/^}$/ d'''
+            cmd[3:] = [sedscript, EFI_config]
+            call(cmd)
+            with open(EFI_config, 'a') as f:
+                f.write(chain)
+
+        if os.path.exists(self.srcmntdir + "/EFI/BOOT"):
+            self._generate_efiboot(isodir)
+
+        self._LiveImageCreatorBase__write_dracut_conf(
+            self._instroot + "/etc/dracut.conf.d/99-liveos.conf")
 
     def tar_cmd(self, operation, opfile, destdir=None, ops=None):
         """Return arguments for tar call and append tarfile name to list."""
@@ -2072,33 +2187,25 @@ s/\s+$//}}'''
         else:
             _proclists('squashfs.img', self.rootfs_img, rootfsimg)
 
-        for f in ('syslinux.cfg', 'extlinux.conf'):
-            cfgf = os.path.join(self.bootfolder, f)
-            if os.path.exists(cfgf): break
-        shutil.copy2(cfgf, cfgf + '.prev')
-        cmd = ['sed', '-i', '-r',]
-        cmd[3:] = [
-        r'''/^\s*menu\s+title\>/I,/^\s*label\s+memtest\>/I s/{0}/{1}/'''.format(
-                     self.release, self.releasefile), cfgf]
-        call(cmd)
+        cmd = ['sed', '-i', '-r']
+        if 'linux' in self.bootpath:
+            for f in ('syslinux.cfg', 'extlinux.conf'):
+                cfgf = os.path.join(self.bootpath, f)
+                if os.path.exists(cfgf): break
 
-        if os.path.dirname(self.bootfolder) != self.srcmntdir:
-            e = os.path.basename(self.liveosdir.rstrip('/'))
-            dn = ''
-            for c in e:
-                if c in r']\/;$*.^?+|{}&[':
-                    dn += '\\' + c
-                else:
-                    dn += c
-
-            f = cfgf.replace(e + os.sep, '')
-            shutil.copy2(f, f + '.prev')
-            cmd[3:] = [r'''/^\s*label\s+{0}/I {{N;
-                      /{0}/ s/{1}/{2}/}}'''.format(
-                       dn, self.release, self.releasefile), f]
+            shutil.copy2(cfgf, cfgf + '.prev')
+            cmd[3:] = [
+r'''/^\s*menu\s+title\>/I,/^\s*label\s+memtest\>/I s/{0}/{1}/'''.format(
+                         _esc(self.product), _esc(self.releasefile)), cfgf]
             call(cmd)
-        else:
-            dn = ' '
+
+            if os.path.exists(self.liveosdir + '/images'):
+                f = cfgf.replace(e + os.sep, '')
+                shutil.copy2(f, f + '.prev')
+                cmd[3:] = [r'''/^\s*label\s+{0}/I {{N;
+                          /{0}/ s/{1}/{2}/}}'''.format(
+                self._losdn, _esc(self.product), _esc(self.releasefile)), f]
+                call(cmd)
 
         for c in ('BOOT', 'boot'):
             EFI_config = os.path.join(self.srcmntdir,
@@ -2110,8 +2217,8 @@ s/\s+$//}}'''
         c = os.path.join(os.path.dirname(EFI_config), 'BOOT.conf')
         shutil.copy2(c, c + '.prev')
         cmd[3:] = [r'''/^\s*menuentry/ {{N;
-        /{0}\/syslinux\/vmlinuz/ s/{1}/{2}/}}'''.format(
-                    dn, self.release, self.releasefile), EFI_config]
+                       /{0}.*\/vmlinuz/ s/{1}/{2}/}}'''.format(
+          self._losdn, _esc(self.product), _esc(self.releasefile)), EFI_config]
         call(cmd)
 
         # Copy or move new rootfs_img or squashfs.img.
@@ -2151,7 +2258,6 @@ s/\s+$//}}'''
             self.ovltype = 'dir'
             if not self.overlay_size_mb:
                 self.overlay_size_mb = self.ovl_size
-#                self.ovl_fstype = 'dir'
                 if self.liveosmnt and self.liveosmnt.ovlmnt:
                     self.liveosmnt.ovlmnt.mount()
                     ovlmntdir = self.liveosmnt.ovlmntdir
@@ -2160,20 +2266,21 @@ s/\s+$//}}'''
                 self.ovl_fstype = 'ext4'
                 self.ovl_blksz = 4096
 
-            cmd[3:] = [
-            's/rd\.live\.image|liveimg/& rd.live.overlay.overlayfs/', cfgf]
-            call(cmd)
+            if 'linux' in self.bootpath:
+                cmd[3:] = [
+                's/rd\.live\.image|liveimg/& rd.live.overlay.overlayfs/', cfgf]
+                call(cmd)
 
-            cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
+            cmd[3:] = [r'''/{0}.*\/vmlinuz/ {{
             s/rd\.live\.image|liveimg/& rd.live.overlay.overlayfs/}}
-            '''.format(dn), EFI_config]
+            '''.format(self._losdn), EFI_config]
             call(cmd)
 
         elif self.overlay_size_mb and self.ovl_fstype == 'DM_snapshot_cow':
             cmd[3:] = ['s/ rd\.live\.overlay\.overlayfs//g', cfgf]
             call(cmd)
 
-            cmd[3:] = [r'/{0}/ s/ rd\.live\.overlay\.overlayfs//g'.format(dn),
+            cmd[3:] = [r'/{0}/ s/ rd\.live\.overlay\.overlayfs//g'.format(self._losdn),
                        EFI_config]
             call(cmd)
 
@@ -2191,21 +2298,26 @@ s/\s+$//}}'''
                                                   self.ovl_blksz)
             self.liveosmnt.cleanup()
             self.liveosmnt.overlay = overlay[0]
-            cmd[3:] = [r'''/^\s*append/ {{
-            s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/}}
-            '''.format(overlay[1]), cfgf]
-            call(cmd)
-            cmd[3:] = [r'''/{0}\/syslinux\/vmlinuz/ {{
+            if 'linux' in self.bootpath:
+                cmd[3:] = [r'''/^\s*append/ {{
+                s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={0}/}}
+                '''.format(overlay[1]), cfgf]
+                call(cmd)
+            cmd[3:] = [r'''/{0}.*\/vmlinuz/ {{
             s/rd\.live\.image|liveimg/& rd.live.overlay=UUID={1}/}}
-            '''.format(dn, overlay[1]), EFI_config]
+            '''.format(self._losdn, overlay[1]), EFI_config]
             call(cmd)
         elif self.ovltype != 'DM_linear':
             self.liveosmnt.reset_overlay()
 
         cmd[3:] = [r'''/^\s*append|linuxefi/I {{
-        :w;s/(\s+\S+)\s*(.*)\1(\s+|$)/\1 \2\3/g;tw
+        :w;s/(\s+\S+)\s+(.*)\1(\s+|$)/\1 \2\3/g;tw
         s/\>\s\s+/ /g
-        s/\s+$//}}''', cfgf, EFI_config]
+        s/\s+$//}}''']
+        if 'linux' in self.bootpath:
+            cmd.append(cfgf)
+        if EFI_config:
+            cmd.append(EFI_config)
         call(cmd)
 
         shutil.copy2(EFI_config, c)
@@ -2254,23 +2366,27 @@ s/\s+$//}}'''
                 p[0][0] = ''
                 p[0] += [False]
 
-        cmd = ['sed', '-n', '-r']
-        sedscript = r'''/^\s*label\s+linux/I {n;n;n
-                      s/^\s*append\s+initrd=\S+\s+(.*)/\1/Ip;q}'''
-        cmd.extend([sedscript, cfgf])
+        if 'linux' in self.bootpath:
+            cmd[3:] = r'''/^\s*label\s+linux/I {n;n;n
+                            s/^\s*append\s+initrd=\S+\s+(.*)/\1/Ip;q}'''
+            cmd.append(cfgf)
+        if EFI_config:
+            cmd[3:] = r'''0,/^\s*linuxefi\s*{0}/ {{
+            s/^\s*linuxefi\s*{0}\S+vmlinuz?*\s+(.*)/\1/p'''.format(self._losdn)
+            cmd.append(EFI_config)
         kcmdline, err, rc = rcall(cmd)
         kcmdline = kcmdline.rstrip()
 
         # self.kernel_release below is from last invocation of
-        #  check_kernel_versions(editor.bootfolder, 'source image')
+        #  check_kernel_versions(editor.bootpath, 'source image')
         if self.src_fstype == 'f2fs' and p2[0]:
             d, err, rc = rcall(['dump.f2fs', self.src_partition])
             if 'extra_attr' in d:
                 p2[2].mount()
                 d = p2[2].mountdir
-                if dn == ' ':
-                    dn = 'LiveOS'
-                e = os.path.join(d, 'linux_' + dn + '.efi')
+                if self._losdn == ' ':
+                    self._losdn = 'LiveOS'
+                e = os.path.join(d, 'linux_' + self._losdn + '.efi')
                 cmd = ['sed', '-znr']
                 cmd[2:] = [r'''1,/^[0-9]+\.[0-9]+\.[0-9]+/ {
                 s/^([0-9]+\.[0-9]+\.[0-9]+\S+)\s+.*/\1/p}''', e]
@@ -2280,13 +2396,14 @@ s/\s+$//}}'''
                 if (kcmdline != self.kcmdline0 or (efistub_kernel and
                     self.kernel_release != efistub_kernel)):
                     self.liveosmnt.mount()
-                    dracut_cmd = ['dracut', e, '--uefi', '--kmoddir',
-                    os.path.join(self.liveosmnt.mountdir, 'usr', 'lib',
-                    'modules', self.kernel_release), '--kver',
-                    self.kernel_release, '--no-machineid', '--kernel-image',
-                    os.path.join(self.bootfolder, 'vmlinuz'), '--no-hostonly',
-                    '--add', 'dmsquash-live', '--add-drivers', 'f2fs',
-                    '--kernel-cmdline', kcmdline, '--force']
+                    dracut_cmd = ['dracut', e, '--uefi', '--sysroot',
+                    self.liveosmnt.mountdir, '--kmoddir', os.path.join(
+                    self.liveosmnt.mountdir, 'usr', 'lib', 'modules',
+                    self.kernel_release), '--kver', self.kernel_release,
+                    '--no-machineid', '--kernel-image', os.path.join(
+                    self.bootpath, 'vmlinuz'), '--no-hostonly', '--add',
+                    'dmsquash-live', '--add-drivers', 'f2fs',
+                    '--kernel-cmdline', kcmdline, '--zstd', '--force']
                     print('\nUpdating %s using this command:\n\n%s' %
                           (os.path.basename(e), dracut_cmd))
                     call(dracut_cmd)
@@ -2297,12 +2414,14 @@ s/\s+$//}}'''
             self.liveosmnt.mount('rw')
             restore_from_tar(self.liveosmnt.mountdir)
             [os.remove(f) for f in self.seclude_tar]
-#           TODO Implement homefsck support, such as below.
-#            if self.src_type == 'live' and os.path.exists(self.home_img):
-#                # Tag to signal a home fsck, if implemented in startup script.
-#                fd = open(os.path.join(self.liveosmnt.mountdir,
-#                                       'forcehomefsck'), 'w')
-#                fd.close()
+
+#       TODO Implement homefsck support in livesys scripts.
+        if self.src_type == 'live' and os.path.exists(self.home_img):
+            # Tag to signal a home fsck, if implemented in startup script.
+            with open(os.path.join(self.liveosdir,
+                                   'forcehomefsck'), 'w') as f:
+                f.write(self.liveosdir)
+                f.flush()
 
         if hasattr(self, 'newhome_img'):
             self.newhomemnt.cleanup()
@@ -2337,7 +2456,7 @@ s/\s+$//}}'''
         if self.newhomemnt:
             self.newhomemnt.cleanup()
         if self._LoopImageCreator__instloop:
-            self._LoopImageCreator__instloop.cleanup()
+            self._LoopImageCreator__instloop.unmount()
 
 
     class simpleCallback:
@@ -2400,6 +2519,18 @@ def copypaths(pathlist, dst_dir, ignore_list=[], parents=None, message=None):
                     raise CreatorError("Failed to copy '%s': %s" % (fp, e))
     if tgt_list and message:
         print("\n%s\n  %s" % (message, tgt_list))
+
+def _esc(str):
+    """
+    Escape a variable string needed in sed scripts.
+    """
+    _str = ''
+    for c in str:
+        if c in r']\/;$*.^?+|{}&[':
+            _str += '\\' + c
+        else:
+            _str += c
+    return _str
 
 
 def main():
@@ -2609,6 +2740,7 @@ def main():
               "mapper type overlay.\n", file=sys.stderr)
         return 1
     editor.kernelargs = args.kernelargs
+    editor.dracut_args = args.dracut_args
     editor.extra_space = int(args.extra_space_mb) * 1024 ** 2
 
     try:
@@ -2625,20 +2757,18 @@ def main():
                                                    editor.ks)
         editor._pre_mount(args.liveos, args.rootfsimg, args.overlay)
         editor.mount(editor.cachedir)
-        isodir = editor.bootfolder
         editor.kernels = None
-        editor.check_kernel_versions(editor.bootfolder, 'current image')
-        editor.check_kernel_versions(os.path.join(editor.imagesdir, 'pxeboot'),
-            'current .iso')
+        editor.check_kernel_versions(editor.bootpath, 'current image')
+        if not editor.bootpath == os.path.join(editor.imagesdir, 'pxeboot'):
+            editor.check_kernel_versions(os.path.join(
+                                  editor.imagesdir, 'pxeboot'), 'current .iso')
         editor.kernel_version0 = editor.kernel_release
         editor.initrd_kernel0 = editor.initrd_kernel
         editor.kernels0 = editor.kernels
-        if not editor.refresh_only:
-            isodir = os.path.join(editor._LiveImageCreatorBase__isodir,
-                                  'isolinux')
+        isodir = editor._LiveImageCreatorBase__isodir
         editor._brand(isodir)
         if not editor.refresh_only:
-            editor._configure_bootloader(editor._LiveImageCreatorBase__isodir)
+            editor._configure_bootloader(isodir)
         if editor.ks:
             # Run_pre_scripts same code as ImageCreator_run_post_scripts
             # editor._run_post_scripts()
@@ -2651,20 +2781,26 @@ def main():
             print('''Launching shell. Exit (Ctrl D) to continue.
                   \r-------------------------------------------''')
             ops = None
-            editor.launch_shell()
+            editor.launch_shell(PS1='[\\u@\\H:install_root\\w:]\\n\\$ ')
 
         editor.kernels = None
-        editor.check_kernel_versions(isodir, 'update')
+        editor.bootpath = os.path.join(isodir, editor._imgdir)
+        editor.check_kernel_versions(editor.bootpath, 'update')
         if not editor.refresh_only:
-            editor.check_kernel_versions(os.path.join(
-                editor._LiveImageCreatorBase__isodir, 'images', 'pxeboot'),
-                'new .iso')
-            editor.check_kernel_versions(isodir, 'new install image')
+            editor.check_kernel_versions(
+                os.path.join(isodir, 'images', 'pxeboot'), 'new .iso')
+            if not editor.bootpath == os.path.join(isodir, 'images', 'pxeboot'):
+                editor.check_kernel_versions(
+                    editor.bootpath, 'new install image')
+            if os.path.exists(
+                editor._instroot + '/etc/dracut.conf.d/99-liveos.conf'):
+                os.remove(
+                    editor._instroot + '/etc/dracut.conf.d/99-liveos.conf')
         if ((not editor.src_type == 'iso' or editor.skip_refresh) and
             not hasattr(editor, 'isosrcmnt')):
             editor.check_kernel_versions(os.path.join(editor.imagesdir,
                 'pxeboot'), 'source PXE')
-            editor.check_kernel_versions(editor.bootfolder, 'source image')
+            editor.check_kernel_versions(editor.bootpath, 'source image')
         if editor.liveosmnt:
             if editor.refresh_only:
                 editor.liveosmnt.cleanup()
@@ -2695,13 +2831,12 @@ def main():
         if not editor.refresh_only and not editor.skip_seclude:
             editor.seclude_from_isoimage()
         if editor.liveosmnt:
-            editor.liveosmnt.cleanup()
+            editor.liveosmnt.unmount()
 
         editor.unmount()
 
-        if editor.src_type == 'iso':
-            editor.liveosmnt.imgloop.cleanup()
-            editor.liveossrc.cleanup()
+        if hasattr(editor.liveosmnt, 'squashmnt'):
+            editor.liveosmnt.squashmnt.cleanup()
         editor._LiveImageCreatorBase__implant_md5sum = editor.refresh
         print('The new image will now be packaged. Please wait...')
         ops = ['show-squashing']
@@ -2709,6 +2844,8 @@ def main():
             ops += ['flatten-squashfs']
         # package() calls refresh(), if requested.
         editor.package(output, ops)
+        if editor.liveossrc:
+            editor.liveossrc.cleanup()
 
         if not editor.refresh_only:
             print("\n%s.iso saved to %s"  % (editor.name, editor.output))

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -5,6 +5,7 @@
 # Copyright 2007, Red Hat  Inc.
 # Copyright 2016, Kevin Kofler
 # Copyright 2016, Neal Gompa
+# Copyright 2023, Fedora Project
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +20,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-from __future__ import print_function
 import os
 import os.path
 import sys
@@ -46,28 +46,32 @@ def parse_options(args):
                       help="Add packages to an existing live CD iso9660 image.")
     imgopt.add_option("-f", "--fslabel", type="string", dest="fslabel",
                       help="File system label (default based on config name)")
-    imgopt.add_option("", "--title", type="string", dest="title",
-                      help="Title used by syslinux.cfg file"),
-    imgopt.add_option("", "--product", type="string", dest="product",
-                      help="Product name used in syslinux.cfg boot stanzas and countdown"),
-    imgopt.add_option("", "--nomacboot", action="store_true",
-                      dest="nomacboot", default=False,
-                      help="Do not create HFS boot image")
-    # Provided for img-create compatibility
+    # Provided for imgcreate compatibility
     imgopt.add_option("-n", "--name", type="string", dest="fslabel",
                       help=optparse.SUPPRESS_HELP)
-    imgopt.add_option("-p", "--plugins", action="store_true", dest="plugins",
-                      help="Use DNF plugins during image creation",
-                      default=False)
-    imgopt.add_option("", "--image-type", type="string", dest="image_type",
-                      help=optparse.SUPPRESS_HELP)
+    imgopt.add_option("", "--title", type="string", dest="title",
+                      help="Title used in syslinux.cfg file"),
+    imgopt.add_option("", "--product", type="string", dest="product",
+                      help="Product name used in boot configurationstanzas and "
+                           "countdown."),
+    imgopt.add_option("", "--releasever", type="string", dest="releasever",
+                      default=None,
+                      help="Value to substitute for $releasever in kickstart repo urls")
+    imgopt.add_option("", "--syslinux", action="store_true",
+                      dest="syslinux", default=False,
+                      help="Use SYSLINUX for BIOS booting.")
+    imgopt.add_option("", "--nomacboot", action="store_true",
+                      dest="nomacboot", default=False,
+                      help="Do not create HFS+ boot image or partition.")
     imgopt.add_option("", "--flat-squashfs", action="store_true",
                       dest="flat_squashfs",
                       help="Specify squashing the root filesystem directly. "
                            "This eliminates the intermediate LiveOS directory "
-                           "and is suitable only for OverlayFS overlays.",
+                           "holding another filesystem image file.  This is "
+                           "suitable only for OverlayFS overlays.",
                       default=False)
     imgopt.add_option("", "--compression-type", type="string", dest="compress_args",
+                      metavar='"TYPE ARG1 ARG2 ..."',
                       help="Compression type recognized by mksquashfs. "
                            "(The default, xz, needs a 2.6.38+ kernel; gzip works "
                            "with all kernels; lzo needs a 2.6.36+ kernel; lz4 "
@@ -78,6 +82,29 @@ def parse_options(args):
                            "Multiple arguments should be specified in "
                            'one string, i.e., --compression-type "type arg1 arg2 ...".',
                       default="xz")
+    imgopt.add_option("", "--dracut-args", type="string",
+                      dest="dracut_args", default="", metavar='"[+]ARG0 ARG1 ..."',
+                      help="The arguments to be used by dracut to configure "
+                           "the initrd. Saved at /etc/dracut.conf.d/99-liveos.conf. "
+                           "This file persists only for the life of the install_root "
+                           "mount.  (A future version of dracut will save this file "
+                           "in the initrd under /usr/lib/dracut/conffiles/ or another "
+                           "regular path.)  Each argument consists of an attribute and "
+                           "a value (see dracut.conf.5). If the first argument string is "
+                           "prefixed with a '+' character, the additional arguments will "
+                           "be appended to the default set (superseding any there):\n "
+                           "mdadmconf=no "
+                           "lvmconf=no "
+                           "compress=xz "
+                           "add_dracutmodules+=\" livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net \" "
+                           "omit_dracutmodules+=\" plymouth \" "
+                           "hostonly=no "
+                           "early_microcode=no ")
+    imgopt.add_option("-p", "--plugins", action="store_true", dest="plugins",
+                      help="Use DNF plugins during image creation",
+                      default=False)
+    imgopt.add_option("", "--image-type", type="string", dest="image_type",
+                      help=optparse.SUPPRESS_HELP)
     imgopt.add_option("", "--repo", type="string", dest="repo",
                       default=None,
                       help="Configure RPM repositories from a .repo file or directory "
@@ -92,35 +119,39 @@ def parse_options(args):
                            "trusted GPG signatures and strong digests for every "
                            "package. Only affects packages installed during the "
                            "%install step.")
-    imgopt.add_option("", "--releasever", type="string", dest="releasever",
-                      default=None,
-                      help="Value to substitute for $releasever in kickstart repo urls")
     parser.add_option_group(imgopt)
 
     # options related to the config of your system
     sysopt = optparse.OptionGroup(parser, "System directory options",
-                                  "These options define directories used on your system for creating the live image")
+            "These options define directories used on your system for creating the live image")
     sysopt.add_option("-t", "--tmpdir", type="string",
                       dest="tmpdir", default="/var/tmp",
                       help="Temporary directory to use (default: /var/tmp)")
+    sysopt.add_option("-o", "--output", type="string",
+                      dest="destdir", default=".",
+                      help="The directory path where the image .iso will be saved (default: '.')")
     sysopt.add_option("", "--cache", type="string",
                       dest="cachedir", default=None,
                       help="Cache directory to use (default: private cache")
     sysopt.add_option("", "--cacheonly", action="store_true",
                       dest="cacheonly", default=False,
                       help="Work offline from cache, use together with --cache (default: False)")
+    # Start a shell in the chroot for post-configuration.
+    sysopt.add_option("-l", "--shell", action="store_true", dest="give_shell",
+                      help="Launch a change root shell in the installation "
+                           "root filesystem. This includes bind mounts to the host "
+                           "directories /dev, /dev/pts, /dev/shm, /proc, /sys, "
+                           "/sys/fs/selinux, the creator iso directory (mounted at "
+                           "/run/iso), and the host root filesystem (mounted at "
+                           "/run/hostroot).")
     sysopt.add_option("", "--nocleanup", action="store_true",
                       dest="nocleanup", default=False,
                       help="Skip cleanup of temporary files")
-
     parser.add_option_group(sysopt)
 
     imgcreate.setup_logging(parser)
 
     # debug options not recommended for "production" images
-    # Start a shell in the chroot for post-configuration.
-    parser.add_option("-l", "--shell", action="store_true", dest="give_shell",
-                      help=optparse.SUPPRESS_HELP)
     # Don't compress the image.
     parser.add_option("-s", "--skip-compression", action="store_true", dest="skip_compression",
                       help=optparse.SUPPRESS_HELP)
@@ -250,6 +281,13 @@ def main():
         logging.error(u"%s creation failed: %s", options.image_type, e)
         return 1
 
+    if options.syslinux:
+        creator.BIOSbooter = 'SYSLINUX'
+    else:
+        creator.BIOSbooter = 'GRUB'
+
+    creator.dracut_args = options.dracut_args
+    creator.flat_squashfs = options.flat_squashfs
     creator.compress_args = options.compress_args
     creator.skip_compression = options.skip_compression
     creator.skip_hfs = options.nomacboot
@@ -260,19 +298,32 @@ def main():
     try:
         creator.mount(options.base_on, options.cachedir)
         creator.install({}, options.repo, options.pkgverify_level)
-        if (options.flat_squashfs and
-          'rd.live.overlay.overlayfs' not in ks.handler.bootloader.appendLine):
-            ks.handler.bootloader.appendLine += 'rd.live.overlay.overlayfs'
         creator.configure()
         if options.give_shell:
-            print("Launching shell. Exit to continue.")
-            print("----------------------------------")
-            creator.launch_shell()
+            creator._ImageCreator__load_selinuxfs()
+            bindmounts = [('/dev', None), ('/run', None),
+                          ('/etc/resolv.conf', None),
+                          (creator._LiveImageCreatorBase__isodir, '/run/iso'),
+                          ('/', '/run/hostroot')]
+            for (f, dest) in bindmounts:
+                if os.path.exists(f):
+                    creator._ImageCreator__bindmounts.extend(
+                    [imgcreate.fs.BindChrootMount(f, creator._instroot, dest)])
+                else:
+                    logging.warning("Skipping (%s, %s) because source doesn't "
+                                 "exist." % (f, dest))
+            creator._do_bindmounts()
+            print("Launching shell. Exit (Ctrl D) to continue.")
+            print("-------------------------------------------")
+            creator.launch_shell(PS1='[\\u@\\H:install_root\\w:]\\n\\$ ')
+            creator._ImageCreator__destroy_selinuxfs()
+            imgcreate.ImageCreator._undo_bindmounts(creator)
+            imgcreate.kickstart.SelinuxConfig(creator._instroot).apply(creator.ks.handler.selinux)
         creator.unmount()
         ops = []
-        if 'rd.live.overlay.overlayfs' in ks.handler.bootloader.appendLine:
+        if options.flat_squashfs:
             ops += ['flatten-squashfs']
-        creator.package(ops=ops)
+        creator.package(options.destdir, ops=ops)
     except (imgcreate.CreatorError, DnfBaseError) as e:
         logging.error(u"Error creating Live CD : %s" % e)
         return 1

--- a/tools/liveimage-mount
+++ b/tools/liveimage-mount
@@ -6,7 +6,7 @@
 #
 # Copyright 2011, Red Hat, Inc.
 # Copyright 2016, Neal Gompa
-# Copyright 2017-2021, Sugar Labs®
+# Copyright 2017-2023, Sugar Labs®
 #   Code for Live mounting an attached LiveOS device added by Frederick Grose,
 #   <fgrose at sugarlabs.org>
 #   Ported to Python 3 by Neal Gompa <ngompa13 at gmail.com>
@@ -337,6 +337,7 @@ def main():
     ovl_mp = ''
     dnfcache = ''
     tempfile.tempdir = '/tmp'
+    overlayfs = None
     for o, a in ops:
         if o in ('-h', '-?', '--help'):
             usage()
@@ -589,12 +590,10 @@ def main():
             mount([liveos, liveosmnt], ops)
             unmount = 'yes'
 
-        cfgf = os.path.join(liveosmnt, 'syslinux', 'syslinux.cfg')
-        if not os.path.exists(cfgf):
-            cfgf = os.path.join(liveosmnt, 'syslinux', 'extlinux.conf')
+        cfgf = os.path.join(liveosmnt, 'EFI', 'BOOT', 'grub.cfg')
         cmd = ['sed', '-n', '-r']
-        sedscript = r'''/^\s*label\s+linux/{n;n;n
-                        s/^\s*append\s+.*rd\.live\.dir=([^ ]*) .*/\1/p}'''
+        sedscript = r'''0,/^\s*linuxefi/ {
+                s/^\s*linuxefi\s+\\images.*rd\.live\.dir=(\S+)( .*|$)/\1/p}'''
         cmd.extend([sedscript, cfgf])
         liveosdir, err, rc = rcall(cmd)
         liveosdir = liveosdir.rstrip()
@@ -749,7 +748,6 @@ def main():
         d = os.path.join(destmnt, 'dev', 'live-base')
         if os.path.lexists(d):
             os.unlink(d)
-        os.symlink(imgloop, d)
 
         home_path = os.path.join(liveosdir, 'home.img')
         if os.path.exists(home_path):


### PR DESCRIPTION
```txt
    imgcreate, editliveos: Refactor to Fedora 37 image layout.
    
    Accommodate the GRUB-only boot .iso image layout.
    
    Also,
    In livecd-creator:
    Enhance the interactive shell in livecd-creator with
      a path-descriptive prompt string, and
      additional bind mounts to facilitate ad-hoc customization
        from the host shell.
    Provide new livecd-creator options:
      --syslinux    to select this BIOS boot option (default: False),
      --dracut-args "[+]arg0 arg1 ..."  to configure the initrd image,
      -o, --output <path>               the directory path for saving
                                        the .iso image (default: '.').
    Remove an obsolete import directive.
    
    In dnfinst.py:
    Remove an obsolete import directive.
    
    In kickstart.py:
    Provide 'Setting SELinux contexts...' message in the console
      while the install root is being relabelled.
    Adjust default kernel arguments so that 'quiet' appears after
      other arguments in the primary menuentry kernel command line.
    
    In creator.py:
    Name the root filesystem image file 'rootfs.img'.
    Support setting a prompt string in launch_shell().
    Break out __load_selinuxfs() from __create_selinuxfs().
    Use python reversed(__bindmounts) during unmount() so as to
      preserve order for remounting before launch_shell().
    
    In fs.py:
    Allow '-progress' to be effective when passed to mksquashfs
      in compress_args.
    Perform recursive unmount in class BindChrootMount().
    Use blkid instead of lsblk in LoopbackDisk to determine
      filesystem type.
    Adjust default F2FS mkfs option to 'sb_checksum' from
      'extra_attr,compression'.
    Explictly remove temporary overlay backing file on cleanup
      of class LiveImageMount().
    
    In live.py:
    Define default dracut arguments for the temporary file
      99-liveos.conf, which can be modified with the new
      --dracut-args option to livecd-creator and editliveos.
      Remove '=ata' from modules &
             'ide-cd', 'ieee1394' from extra_drivers.
             These fail in dracut with F36 and F37.
    Incorporate licenses, README files, and, if present,
      livecd-iso-to-disk into the .iso at build time rather than
      during post processing of the kickstart.
    Preserve file attributes on copying kernel and boot files to
      aid in recognizing file provenance.
    Set x86LiveImageCreator xorrisofs options and GRUB menu options
      to match lorax and livemedia-creator (but continue to index
      the kernel and initrd files).
    
    In editliveos:
    Default to zstd compressor for dracut compression if a new
      initrd is needed.
    Provide option --dracut-args "[+]arg0 arg1 ..."  to configure the
      initrd image through /etc/dracut.conf.d/99-liveos.conf
    Fix sed command string for removing duplicate words.
    Escape variable strings used in sed statements.
    Provide a default --builder name if env('USERNAME') is not set,
      (thanks to Charlie Woolf).
    Remove some end-of-line spaces.
    
    Update documentation.
```

Note:  These changes have been tested on x86_64 only (no xen) and successfully build and boot Fedora 36 and 37 images both in SYSLINUX and UEFI for Fedora 36 and GRUB2 BIOS and UEFI for Fedora 37 and iso-scan/filename.

More extensive changes to livecd-iso-to-disk are pending further testing.

Also pending is an update to fedora-live-base.ks to drop the post processing of license/release & livecd-iso-to-disk.