### PR TITLE
Refactor to permit base-on of flattened SquashFS only images.

### DIFF
--- a/docs/livecd-creator.pod
+++ b/docs/livecd-creator.pod
@@ -80,7 +80,7 @@ Set to C<None> to force reading the compressor used in BASE_ON.
 If C<gzip> is used, the -comp option is not passed to mksquashfs to allow the use of older versions of mksquashfs.
 Multiple arguments should be specified in one string, i.e., C<--compression-type "type arg1 arg2 ...">.
 
-=item --dracut-args="[+]ARG0 ARG1 ..."
+=item --dracut-conf-args="[+]ARG0 ARG1 ..."
 
 The arguments that will be used by dracut to configure the initrd and be saved
 at F</etc/dracut.conf.d/99-liveos.conf>. This file persists only for the life of
@@ -89,13 +89,12 @@ the initrd under F<*/lib/dracut/conffiles/> or another regular path.) Each argum
 consists of an attribute and a value (see L<dracut.conf(5)>).
 
 If the first argument string is prefixed with a '+' character, the additional
-arguments will be appended to the default set (superseding any there):
+arguments will be appended to the default set (superseding any there by default):
 
   mdadmconf=no
   lvmconf=no
-  compress=xz
-  add_dracutmodules+=" livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net "
-  omit_dracutmodules+=" plymouth "
+  compress=zstd
+  add_dracutmodules+=" livenet dmsquash-live dmsquash-live-autooverlay dmsquash-live-ntfs overlayfs convertfs pollcdrom qemu qemu-net "
   hostonly=no
   early_microcode=no
 

--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -481,6 +481,7 @@ class ImageCreator(object):
         os.umask(origumask)
 
     def __load_selinuxfs(self):
+        print('Setting SELinux contexts...')
         arglist = ["mount", "--bind", "/dev/null",
                    self._instroot + self.__selinux_mountpoint + "/load"]
         subprocess.call(arglist, close_fds = True)
@@ -570,7 +571,8 @@ class ImageCreator(object):
 
         self.__create_minimal_dev()
 
-        os.symlink("/proc/self/mounts", self._instroot + "/etc/mtab")
+        if not os.path.lexists(self._instroot + "/etc/mtab"):
+            os.symlink("/proc/self/mounts", self._instroot + "/etc/mtab")
 
         self.__write_fstab()
 
@@ -1001,15 +1003,15 @@ class LoopImageCreator(ImageCreator):
     def _mount_instroot(self, base_on = None):
         self.__imgdir = self._mkdtemp()
 
-        if not base_on is None:
-            self._base_on(base_on)
-
         self.__instloop = ExtDiskMount(SparseLoopbackDisk(self._image,
                                                           self.__image_size),
                                        self._instroot,
                                        self._fstype,
                                        self.__blocksize,
                                        self.fslabel)
+
+        if not base_on is None:
+            self._base_on(base_on)
 
         try:
             self.__instloop.mount()

--- a/imgcreate/dnfinst.py
+++ b/imgcreate/dnfinst.py
@@ -85,6 +85,8 @@ class DnfLiveCD(dnf.Base):
         conf += "obsoletes=1\n"
         conf += "best=1\n"
         conf += "tsflags=nocontexts\n"
+        # For testing purposes only:
+        # conf += "tsflags=nocrypto\n"
 
         f = open(confpath, "w+")
         f.write(conf)

--- a/tools/livecd-creator
+++ b/tools/livecd-creator
@@ -82,8 +82,8 @@ def parse_options(args):
                            "Multiple arguments should be specified in "
                            'one string, i.e., --compression-type "type arg1 arg2 ...".',
                       default="xz")
-    imgopt.add_option("", "--dracut-args", type="string",
-                      dest="dracut_args", default="", metavar='"[+]ARG0 ARG1 ..."',
+    imgopt.add_option("", "--dracut-conf-args", type="string",
+                      dest="dracut_conf_args", default="", metavar='"[+]ARG0 ARG1 ..."',
                       help="The arguments to be used by dracut to configure "
                            "the initrd. Saved at /etc/dracut.conf.d/99-liveos.conf. "
                            "This file persists only for the life of the install_root "
@@ -286,7 +286,7 @@ def main():
     else:
         creator.BIOSbooter = 'GRUB'
 
-    creator.dracut_args = options.dracut_args
+    creator.dracut_conf_args = options.dracut_conf_args
     creator.flat_squashfs = options.flat_squashfs
     creator.compress_args = options.compress_args
     creator.skip_compression = options.skip_compression
@@ -297,7 +297,8 @@ def main():
 
     try:
         creator.mount(options.base_on, options.cachedir)
-        creator.install({}, options.repo, options.pkgverify_level)
+        if not (options.give_shell and options.base_on):
+            creator.install({}, options.repo, options.pkgverify_level)
         creator.configure()
         if options.give_shell:
             creator._ImageCreator__load_selinuxfs()
@@ -316,6 +317,7 @@ def main():
             print("Launching shell. Exit (Ctrl D) to continue.")
             print("-------------------------------------------")
             creator.launch_shell(PS1='[\\u@\\H:install_root\\w:]\\n\\$ ')
+            os.system('umount -R ' + creator._instroot + '/dev')
             creator._ImageCreator__destroy_selinuxfs()
             imgcreate.ImageCreator._undo_bindmounts(creator)
             imgcreate.kickstart.SelinuxConfig(creator._instroot).apply(creator.ks.handler.selinux)

--- a/tools/liveimage-mount
+++ b/tools/liveimage-mount
@@ -865,9 +865,9 @@ def main():
                 Please wait if large files were written.''')
             if os.path.ismount(src):
                 call(['umount', src])
-                if os.path.exists(src):
-                    os.rmdir(src)
             cleanup()
+            if os.path.exists(src):
+                os.rmdir(src)
 
     sys_exit(ecode)
 


### PR DESCRIPTION
```txt
Use unsquashfs to decompress flattened image directly to the
  _instroot.
Avoid kickstart installations when a change root shell is requested
  in a livecd-creator session that employs a base-on image.  This
  makes sequential editing of an image quicker.

Also:
Include F2FS drivers in the initrd.
Default to zstd compression to favor more rapid decompression.
Include the dracut modules dmsquash-live-autooverlay & overlayfs
  among the defaults.
Revert the explicit omission of plymouth.
Rename dracut_args to dracut_conf_args to match their required
  syntax.
Print a couple of console messages on the activity of the script at
  longer operations.
Assure that mounts are unmounted in the necessary order.
Update documentation.
```
************************************
These changes have been tested with Fedora-Workstation-Live-x86_64-38-20230224.n.0.iso