### PR TITLE
imgcreate: support kickstart 'module' command

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -738,6 +738,7 @@ class ImageCreator(object):
 
         dbo.fill_sack(load_system_repo = os.path.exists(self._instroot + "/var/lib/rpm/Packages"))
         dbo.read_comps()
+        dbo.setModules(kickstart.get_modules(self.ks))
 
         try:
             self.__apply_selections(dbo)

--- a/imgcreate/dnfinst.py
+++ b/imgcreate/dnfinst.py
@@ -271,6 +271,33 @@ class DnfLiveCD(dnf.Base):
         """
         self.pkgverify_level = pkgverify_level
 
+    def setModules(self, module_list):
+        """
+        Enables/disables repo modules as requested by kickstart 'module' commands
+        """
+        if not module_list:
+            return
+        try:
+            import dnf.module.module_base
+        except ImportError:
+            raise CreatorError(
+                "Unable to setup modules: your DNF does not seem to support modules")
+        enabled = []
+        disabled = []
+        for (name, stream, enable) in module_list:
+            if enable:
+                if stream:
+                    enabled.append("%s:%s" %(name, stream))
+                else:
+                    enabled.append(name)
+            else:
+                disabled.append(name)
+        module_base = dnf.module.module_base.ModuleBase(self)
+        if enabled:
+            module_base.enable(enabled)
+        if disabled:
+            module_base.disable(disabled)
+
     def runInstall(self):
         """
         Install packages

--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -580,6 +580,12 @@ def get_default_kernel(ks, default = None):
         return default
     return ks.handler.bootloader.default
 
+def get_modules(ks):
+    modules = []
+    for module in ks.handler.module.moduleList:
+        modules.append((module.name, module.stream, module.enable if hasattr(module, "enable") else True))
+    return modules
+
 def get_repos(ks, repo_urls = {}):
     repos = {}
     for repo in ks.handler.repo.repoList:


### PR DESCRIPTION
Closes #201.

Hopefully this is okay... I'm not confident at all in dnf internals, but:

a) it seems working (I was able to install nodejs-18 instead of non-modular nodejs-16 when building Alma 9.2 image using `module --name=nodejs --stream=18` command). Also the default stream (no `--stream`) and `--disable` seem working.

b) I took care this code does nothing when there are no `module` command(s) in kickstart file. However, previously the command was silently ignored, so it still may surprise someone, if they have `module` commands that now will start working.