### PR TITLE
make live image default choice in boot menu

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -823,7 +823,7 @@ menu end
         return fail
 
     def __get_basic_efi_config(self, **args):
-        return """set default="1"
+        return """set default="0"
 
 function load_video {
   insmod efi_gop
@@ -935,7 +935,7 @@ search --no-floppy --set=root -l '%(isolabel)s'
                      "-p", self.product])
 
     def __get_basic_grub2_bios_config(self, **args):
-        return """set default="1"
+        return """set default="0"
 
 function load_video {
   insmod all_video


### PR DESCRIPTION
Is there some reason that "Troubleshooting" is the the default boot menu choise? If not please consider this PR to make booting the live image the default choice.