### PR TITLE
use compression from command line in dracut config

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -332,7 +332,7 @@ class LiveImageCreatorBase(LoopImageCreator):
             args = """
 mdadmconf=no
 lvmconf=no
-compress=zstd
+compress=""" + self.compress_args + """
 add_dracutmodules+=" livenet dmsquash-live dmsquash-live-autooverlay \
 dmsquash-live-ntfs overlayfs convertfs pollcdrom qemu qemu-net "
 hostonly=no


### PR DESCRIPTION
Without this I was not able to build Rocky 8 live image on a Rocky 9 host. Needed to be able to set "--compression-type xz".