### PR TITLE
Fedora 38+ (UEFI-only) live format change workarounds

### DIFF
--- a/tools/livecd-iso-to-disk.sh
+++ b/tools/livecd-iso-to-disk.sh
@@ -2758,6 +2758,7 @@ if [[ ! -f $BOOTCONFIG ]]; then
     # Dummy-up a boot configuration file when missing for EFI boot
     if [[ -n $efi ]]; then
 	echo "#### Unused dummy boot loader configuration file ####" > $BOOTCONFIG
+	echo "SAY BIOS boot not supported. Use UEFI boot." >> $BOOTCONFIG
     else
 	echo "ERROR: Unable to find a non-UEFI boot configuration file."
 	exitclean


### PR DESCRIPTION
  Fallback to pulling kernel/initrd from pxeboot directory if isolinux/syslinux directories not present.
  Sanity check kernel/initrd directory present.
  Set up 100 MB ESP Partition if efiboot.img not present.
  Set up dummy isolinux/syslinux config file if a non-EUFI boot config file is not present in iso and --efi specified.
  Error if no --efi and non-UEFI boot config file not present.